### PR TITLE
Backport PR 1864

### DIFF
--- a/src/analysis/misc_utils.ml
+++ b/src/analysis/misc_utils.ml
@@ -60,6 +60,58 @@ let parse_identifier (config, source) pos =
     (String.concat ~sep:";" (List.map path ~f:(fun l -> l.Location.txt)));
   path
 
+let reconstruct_identifier pipeline pos = function
+  | None ->
+    let config = Mpipeline.input_config pipeline in
+    let source = Mpipeline.raw_source pipeline in
+    let path = parse_identifier (config, source) pos in
+    let reify dot =
+      if
+        dot = ""
+        || (dot.[0] >= 'a' && dot.[0] <= 'z')
+        || (dot.[0] >= 'A' && dot.[0] <= 'Z')
+      then dot
+      else "( " ^ dot ^ ")"
+    in
+    begin
+      match path with
+      | [] -> []
+      | base :: tail ->
+        let f { Location.txt = base; loc = bl } { Location.txt = dot; loc = dl }
+            =
+          let loc = Location_aux.union bl dl in
+          let txt = base ^ "." ^ reify dot in
+          Location.mkloc txt loc
+        in
+        [ List.fold_left tail ~init:base ~f ]
+    end
+  | Some (expr, offset) ->
+    let loc_start =
+      let l, c = Lexing.split_pos pos in
+      Lexing.make_pos (l, c - offset)
+    in
+    let shift loc int =
+      let l, c = Lexing.split_pos loc in
+      Lexing.make_pos (l, c + int)
+    in
+    let add_loc source =
+      let loc =
+        { Location.loc_start;
+          loc_end = shift loc_start (String.length source);
+          loc_ghost = false
+        }
+      in
+      Location.mkloc source loc
+    in
+    let len = String.length expr in
+    let rec aux acc i =
+      if i >= len then List.rev_map ~f:add_loc (expr :: acc)
+      else if expr.[i] = '.' then
+        aux (String.sub expr ~pos:0 ~len:i :: acc) (succ i)
+      else aux acc (succ i)
+    in
+    aux [] offset
+
 let is_current_unit comp_unit =
   match Env.get_unit_name () with
   | Some current_unit ->

--- a/src/analysis/misc_utils.mli
+++ b/src/analysis/misc_utils.mli
@@ -29,6 +29,14 @@ end
 val parse_identifier :
   Mconfig.t * Msource.t -> Lexing.position -> modname Location.loc list
 
+(** [reconstruct_identifier pipeline pos] returns growing ranges around [pos] and the
+  associated identifier. *)
+val reconstruct_identifier :
+  Mpipeline.t ->
+  Lexing.position ->
+  (string * int) option ->
+  string Location.loc list
+
 (* Add parenthesis to qualified operators *)
 val parenthesize_name : string -> string
 

--- a/src/analysis/type_enclosing.ml
+++ b/src/analysis/type_enclosing.ml
@@ -1,4 +1,5 @@
 open Std
+open Type_utils
 
 let log_section = "type-enclosing"
 let { Logger.log } = Logger.for_section log_section
@@ -7,10 +8,33 @@ type type_info =
   | Modtype of Env.t * Types.module_type
   | Type of Env.t * Types.type_expr
   | Type_decl of Env.t * Ident.t * Types.type_declaration
+  | Type_constr of Env.t * Types.constructor_description
   | String of string
 
 type typed_enclosings =
   (Location.t * type_info * Query_protocol.is_tail_position) list
+
+let print_type ~verbosity type_info =
+  let ppf = Format.str_formatter in
+  let wrap_printing_env = Printtyp.wrap_printing_env ~verbosity in
+  match type_info with
+  | Type (env, t) ->
+    wrap_printing_env env (fun () ->
+        print_type_with_decl ~verbosity env ppf t;
+        Format.flush_str_formatter ())
+  | Type_decl (env, id, t) ->
+    wrap_printing_env env (fun () ->
+        Printtyp.type_declaration env id ppf t;
+        Format.flush_str_formatter ())
+  | Type_constr (env, cd) ->
+    wrap_printing_env env (fun () ->
+        print_constr ~verbosity env ppf cd;
+        Format.flush_str_formatter ())
+  | Modtype (env, m) ->
+    wrap_printing_env env (fun () ->
+        Printtyp.modtype env ppf m;
+        Format.flush_str_formatter ())
+  | String s -> s
 
 let from_nodes ~path =
   let aux (env, node, tail) =
@@ -89,14 +113,10 @@ let from_reconstructed ~nodes ~cursor ~verbosity exprs =
     (* Retrieve the type from the AST when it is possible *)
     | Some (Context.Constructor (cd, loc)) ->
       log ~title:"from_reconstructed" "ctx: constructor %s" cd.cstr_name;
-      let ppf, to_string = Format.to_string () in
-      Type_utils.print_constr ~verbosity env ppf cd;
-      Some (loc, String (to_string ()), `No)
+      Some (loc, Type_constr (env, cd), `No)
     | Some (Context.Label ({ lbl_name; lbl_arg; _ }, _)) ->
       log ~title:"from_reconstructed" "ctx: label %s" lbl_name;
-      let ppf, to_string = Format.to_string () in
-      Type_utils.print_type_with_decl ~verbosity env ppf lbl_arg;
-      Some (loc, String (to_string ()), `No)
+      Some (loc, Type (env, lbl_arg), `No)
     | Some Context.Constant -> None
     | _ -> (
       let context = Option.value ~default:Context.Expr context in

--- a/src/analysis/type_enclosing.mli
+++ b/src/analysis/type_enclosing.mli
@@ -38,10 +38,13 @@ type type_info =
   | Modtype of Env.t * Types.module_type
   | Type of Env.t * Types.type_expr
   | Type_decl of Env.t * Ident.t * Types.type_declaration
+  | Type_constr of Env.t * Types.constructor_description
   | String of string
 
 type typed_enclosings =
   (Location.t * type_info * Query_protocol.is_tail_position) list
+
+val print_type : verbosity:Mconfig.Verbosity.t -> type_info -> string
 
 val from_nodes :
   path:(Env.t * Browse_raw.node * Query_protocol.is_tail_position) list ->

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -202,58 +202,6 @@ let dump pipeline = function
        browse, source, parsetree, ppxed-source, ppxed-parsetree, typedtree, \
        env/fullenv (at {col:, line:})"
 
-let reconstruct_identifier pipeline pos = function
-  | None ->
-    let config = Mpipeline.input_config pipeline in
-    let source = Mpipeline.raw_source pipeline in
-    let path = Misc_utils.parse_identifier (config, source) pos in
-    let reify dot =
-      if
-        dot = ""
-        || (dot.[0] >= 'a' && dot.[0] <= 'z')
-        || (dot.[0] >= 'A' && dot.[0] <= 'Z')
-      then dot
-      else "( " ^ dot ^ ")"
-    in
-    begin
-      match path with
-      | [] -> []
-      | base :: tail ->
-        let f { Location.txt = base; loc = bl } { Location.txt = dot; loc = dl }
-            =
-          let loc = Location_aux.union bl dl in
-          let txt = base ^ "." ^ reify dot in
-          Location.mkloc txt loc
-        in
-        [ List.fold_left tail ~init:base ~f ]
-    end
-  | Some (expr, offset) ->
-    let loc_start =
-      let l, c = Lexing.split_pos pos in
-      Lexing.make_pos (l, c - offset)
-    in
-    let shift loc int =
-      let l, c = Lexing.split_pos loc in
-      Lexing.make_pos (l, c + int)
-    in
-    let add_loc source =
-      let loc =
-        { Location.loc_start;
-          loc_end = shift loc_start (String.length source);
-          loc_ghost = false
-        }
-      in
-      Location.mkloc source loc
-    in
-    let len = String.length expr in
-    let rec aux acc i =
-      if i >= len then List.rev_map ~f:add_loc (expr :: acc)
-      else if expr.[i] = '.' then
-        aux (String.sub expr ~pos:0 ~len:i :: acc) (succ i)
-      else aux acc (succ i)
-    in
-    aux [] offset
-
 let dispatch pipeline (type a) : a Query_protocol.t -> a = function
   | Type_expr (source, pos) ->
     let typer = Mpipeline.typer_result pipeline in
@@ -353,10 +301,14 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
       | browse -> Browse_misc.annotate_tail_calls browse
     in
 
-    let result = Type_enclosing.from_nodes ~path in
+    let enclosing_nodes =
+      let cmp (loc1, _, _) (loc2, _, _) = Location_aux.compare loc1 loc2 in
+      (* There might be duplicates in the list *)
+      Type_enclosing.from_nodes ~path |> List.dedup_adjacent ~cmp
+    in
 
     (* enclosings of cursor in given expression *)
-    let exprs = reconstruct_identifier pipeline pos expro in
+    let exprs = Misc_utils.reconstruct_identifier pipeline pos expro in
     let () =
       Logger.log ~section:Type_enclosing.log_section
         ~title:"reconstruct identifier" "%a" Logger.json (fun () ->
@@ -381,41 +333,43 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
              (fun fmt (loc, _, _) -> Location.print_loc fmt loc))
           small_enclosings);
 
-    let ppf = Format.str_formatter in
     let all_results =
-      List.mapi (small_enclosings @ result) ~f:(fun i (loc, text, tail) ->
-          let print =
-            match index with
-            | None -> true
-            | Some index -> index = i
-          in
-          let ret x = (loc, x, tail) in
-          match text with
-          | Type_enclosing.String str -> ret (`String str)
-          | Type_enclosing.Type (env, t) when print ->
-            Printtyp.wrap_printing_env env ~verbosity (fun () ->
-                Type_utils.print_type_with_decl ~verbosity env ppf t);
-            ret (`String (Format.flush_str_formatter ()))
-          | Type_enclosing.Type_decl (env, id, t) when print ->
-            Printtyp.wrap_printing_env env ~verbosity (fun () ->
-                Printtyp.type_declaration env id ppf t);
-            ret (`String (Format.flush_str_formatter ()))
-          | Type_enclosing.Modtype (env, m) when print ->
-            Printtyp.wrap_printing_env env ~verbosity (fun () ->
-                Printtyp.modtype env ppf m);
-            ret (`String (Format.flush_str_formatter ()))
-          | _ -> ret (`Index i))
+      let same_loc (l1, _, _) (l2, _, _) = Location_aux.compare l1 l2 == 0 in
+      let print_type (loc, type_info, tail) =
+        let open Type_enclosing in
+        (loc, String (print_type ~verbosity type_info), tail)
+      in
+      let rec concat_dedup acc l1 l2 =
+        match (l1, l2) with
+        | [ last ], first :: rest ->
+          (* The last reconstructed enclosing might be a duplicate of the first
+             enclosing from the tree. We need to print these enclosings types to
+             check if they differ or not. *)
+          if same_loc last first then
+            let ((_, last_type, _) as last) = print_type last in
+            let ((_, first_type, _) as first) = print_type first in
+            if last_type = first_type then concat_dedup (first :: acc) [] rest
+            else concat_dedup (last :: acc) [] (first :: rest)
+          else concat_dedup (last :: acc) [] l2
+        | hd :: tl, _ -> concat_dedup (hd :: acc) tl l2
+        | [], _ -> List.rev_append acc l2
+      in
+      concat_dedup [] small_enclosings enclosing_nodes
     in
-    let normalize ({ Location.loc_start; loc_end; _ }, text, _tail) =
-      (Lexing.split_pos loc_start, Lexing.split_pos loc_end, text)
-    in
-    (* We remove duplicates from the list. Duplicates can appear when the type
-       from the reconstructed identifier is the same as the one stored in the
-       typedtree *)
-    List.merge_cons
-      ~f:(fun a b ->
-        if compare (normalize a) (normalize b) = 0 then Some b else None)
-      all_results
+    List.mapi all_results ~f:(fun i (loc, text, tail) ->
+        let print =
+          match index with
+          | None -> true
+          | Some index -> index = i
+        in
+        let ret x = (loc, x, tail) in
+        match text with
+        | Type_enclosing.String str -> ret (`String str)
+        | type_info ->
+          if print then
+            let printed_type = Type_enclosing.print_type ~verbosity type_info in
+            ret (`String printed_type)
+          else ret (`Index i))
   | Enclosing pos ->
     let typer = Mpipeline.typer_result pipeline in
     let structures = Mbrowse.of_typedtree (Mtyper.get_typedtree typer) in
@@ -587,7 +541,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
       match patho with
       | Some p -> p
       | None ->
-        let path = reconstruct_identifier pipeline pos None in
+        let path = Misc_utils.reconstruct_identifier pipeline pos None in
         let path = Mreader_lexer.identifier_suffix path in
         let path = List.map ~f:(fun { Location.txt; _ } -> txt) path in
         String.concat ~sep:"." path
@@ -623,7 +577,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
       match patho with
       | Some p -> p
       | None ->
-        let path = reconstruct_identifier pipeline pos None in
+        let path = Misc_utils.reconstruct_identifier pipeline pos None in
         let path = Mreader_lexer.identifier_suffix path in
         let path = List.map ~f:(fun { Location.txt; _ } -> txt) path in
         let path = String.concat ~sep:"." path in
@@ -927,7 +881,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
     let pos = Mpipeline.get_lexing_pos pipeline pos in
     let env, _node = Mbrowse.leaf_node (Mtyper.node_at typer_result pos) in
     let path =
-      let path = reconstruct_identifier pipeline pos None in
+      let path = Misc_utils.reconstruct_identifier pipeline pos None in
       let path = Mreader_lexer.identifier_suffix path in
       let path = List.map ~f:(fun { Location.txt; _ } -> txt) path in
       let path = String.concat ~sep:"." path in

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -309,18 +309,17 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
        typedtree's nodes and can provide types for modules appearing in paths.
 
        This introduces two possible sources of duplicate results:
-       - Sometimes the typedtree nodes in 1 overlaps and we simply remove these.
        - The last reconstructed enclosing usually overlaps with the first
          typedtree node but the printed types are not always the same (generic /
          specialized types). Because systematically printing these types to
          compare them can be very expensive in the presence of large modules, we
          defer this deduplication to the clients.
+       - Sometimes the typedtree nodes in 1 overlaps. We choose not to dedpulicate because
+         if the types are the same, the client is already responsible for deduplication.
+         If they are different, then they are likely useful to display to the user.
+       So, we choose to not duplicate results and delegate this to the client.
     *)
-    let enclosing_nodes =
-      let cmp (loc1, _, _) (loc2, _, _) = Location_aux.compare loc1 loc2 in
-      (* There might be duplicates in the list: we remove them *)
-      Type_enclosing.from_nodes ~path |> List.dedup_adjacent ~cmp
-    in
+    let enclosing_nodes = Type_enclosing.from_nodes ~path in
 
     (* Enclosings of cursor in given expression *)
     let exprs = Misc_utils.reconstruct_identifier pipeline pos expro in

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -356,6 +356,15 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
       in
       concat_dedup [] small_enclosings enclosing_nodes
     in
+    let index =
+      (* Clamp the index to [0; number_of_results[ *)
+      let number_of_results = List.length all_results in
+      match index with
+      | Some index when index < 0 -> Some 0
+      | Some index when index >= number_of_results ->
+        Some (number_of_results - 1)
+      | index -> index
+    in
     List.mapi all_results ~f:(fun i (loc, text, tail) ->
         let print =
           match index with

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -301,13 +301,28 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
       | browse -> Browse_misc.annotate_tail_calls browse
     in
 
+    (* Type enclosing results come from two sources: 1. the typedtree nodes
+       aroung the cursor's position and 2. the result of reconstructing the
+       identifier around the cursor and typing the resulting paths.
+
+       Having the results from 2 is useful because ot is finer-grained than the
+       typedtree's nodes and can provide types for modules appearing in paths.
+
+       This introduces two possible sources of duplicate results:
+       - Sometimes the typedtree nodes in 1 overlaps and we simply remove these.
+       - The last reconstructed enclosing usually overlaps with the first
+         typedtree node but the printed types are not always the same (generic /
+         specialized types). Because systematically printing these types to
+         compare them can be very expensive in the presence of large modules, we
+         defer this deduplication to the clients.
+    *)
     let enclosing_nodes =
       let cmp (loc1, _, _) (loc2, _, _) = Location_aux.compare loc1 loc2 in
-      (* There might be duplicates in the list *)
+      (* There might be duplicates in the list: we remove them *)
       Type_enclosing.from_nodes ~path |> List.dedup_adjacent ~cmp
     in
 
-    (* enclosings of cursor in given expression *)
+    (* Enclosings of cursor in given expression *)
     let exprs = Misc_utils.reconstruct_identifier pipeline pos expro in
     let () =
       Logger.log ~section:Type_enclosing.log_section
@@ -332,30 +347,7 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
           (Format.pp_print_list ~pp_sep:Format.pp_print_space
              (fun fmt (loc, _, _) -> Location.print_loc fmt loc))
           small_enclosings);
-
-    let all_results =
-      let same_loc (l1, _, _) (l2, _, _) = Location_aux.compare l1 l2 == 0 in
-      let print_type (loc, type_info, tail) =
-        let open Type_enclosing in
-        (loc, String (print_type ~verbosity type_info), tail)
-      in
-      let rec concat_dedup acc l1 l2 =
-        match (l1, l2) with
-        | [ last ], first :: rest ->
-          (* The last reconstructed enclosing might be a duplicate of the first
-             enclosing from the tree. We need to print these enclosings types to
-             check if they differ or not. *)
-          if same_loc last first then
-            let ((_, last_type, _) as last) = print_type last in
-            let ((_, first_type, _) as first) = print_type first in
-            if last_type = first_type then concat_dedup (first :: acc) [] rest
-            else concat_dedup (last :: acc) [] (first :: rest)
-          else concat_dedup (last :: acc) [] l2
-        | hd :: tl, _ -> concat_dedup (hd :: acc) tl l2
-        | [], _ -> List.rev_append acc l2
-      in
-      concat_dedup [] small_enclosings enclosing_nodes
-    in
+    let all_results = List.concat [ small_enclosings; enclosing_nodes ] in
     let index =
       (* Clamp the index to [0; number_of_results[ *)
       let number_of_results = List.length all_results in

--- a/tests/test-dirs/hidden-deps/dash-h.t
+++ b/tests/test-dirs/hidden-deps/dash-h.t
@@ -62,6 +62,18 @@ Check the type of `x`, should work.
         },
         "end": {
           "line": 3,
+          "col": 9
+        },
+        "type": "t",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 3,
+          "col": 8
+        },
+        "end": {
+          "line": 3,
           "col": 14
         },
         "type": "int",

--- a/tests/test-dirs/issue1109.t/run.t
+++ b/tests/test-dirs/issue1109.t/run.t
@@ -20,9 +20,9 @@
       },
       "end": {
         "line": 5,
-        "col": 16
+        "col": 14
       },
-      "type": "'a",
+      "type": "'a -> 'a",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/misc/load_path.t
+++ b/tests/test-dirs/misc/load_path.t
@@ -27,6 +27,18 @@ Here is what merlin sees:
         },
         "type": "int",
         "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 16
+        },
+        "type": "int",
+        "tail": "no"
       }
     ],
     "notifications": []

--- a/tests/test-dirs/type-enclosing/constructors_and_paths.t/run.t
+++ b/tests/test-dirs/type-enclosing/constructors_and_paths.t/run.t
@@ -15,6 +15,18 @@ Various parts of the cons.ml:
       },
       "type": "t",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 4,
+        "col": 13
+      },
+      "end": {
+        "line": 4,
+        "col": 14
+      },
+      "type": "t",
+      "tail": "no"
     }
   ]
 
@@ -37,14 +49,14 @@ Various parts of the cons.ml:
     },
     {
       "start": {
-        "line": 7,
-        "col": 2
+        "line": 8,
+        "col": 4
       },
       "end": {
         "line": 8,
-        "col": 11
+        "col": 5
       },
-      "type": "unit",
+      "type": "t",
       "tail": "no"
     }
   ]
@@ -127,13 +139,13 @@ Various parts of the cons.ml:
     {
       "start": {
         "line": 15,
-        "col": 6
+        "col": 12
       },
       "end": {
         "line": 15,
-        "col": 22
+        "col": 15
       },
-      "type": "unit -> M.t",
+      "type": "M.t",
       "tail": "no"
     }
   ]
@@ -233,6 +245,18 @@ the expression reconstructed from  (M|.A 3).
   $ $MERLIN single type-enclosing -position 26:11 -verbosity 0 \
   > -filename ./cons.ml < ./cons.ml | jq ".value[0:2]"
   [
+    {
+      "start": {
+        "line": 26,
+        "col": 8
+      },
+      "end": {
+        "line": 26,
+        "col": 11
+      },
+      "type": "int",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 26,

--- a/tests/test-dirs/type-enclosing/function-type-error.t
+++ b/tests/test-dirs/type-enclosing/function-type-error.t
@@ -28,6 +28,18 @@ type error. The exact output may change slightly -- that's fine.
         },
         "end": {
           "line": 1,
+          "col": 16
+        },
+        "type": "int",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 15
+        },
+        "end": {
+          "line": 1,
           "col": 20
         },
         "type": "int",
@@ -79,6 +91,18 @@ type error. The exact output may change slightly -- that's fine.
   {
     "class": "return",
     "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 27
+        },
+        "end": {
+          "line": 1,
+          "col": 28
+        },
+        "type": "int",
+        "tail": "no"
+      },
       {
         "start": {
           "line": 1,
@@ -159,18 +183,6 @@ type error. The exact output may change slightly -- that's fine.
           "col": 19
         },
         "type": "int",
-        "tail": "no"
-      },
-      {
-        "start": {
-          "line": 1,
-          "col": 8
-        },
-        "end": {
-          "line": 1,
-          "col": 40
-        },
-        "type": "int -> ?z:int -> int -> int",
         "tail": "no"
       },
       {

--- a/tests/test-dirs/type-enclosing/function-type-error.t
+++ b/tests/test-dirs/type-enclosing/function-type-error.t
@@ -194,6 +194,18 @@ type error. The exact output may change slightly -- that's fine.
           "line": 1,
           "col": 40
         },
+        "type": "int -> ?z:int -> int -> int",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 40
+        },
         "type": "int",
         "tail": "no"
       },

--- a/tests/test-dirs/type-enclosing/generic-types.t
+++ b/tests/test-dirs/type-enclosing/generic-types.t
@@ -26,7 +26,7 @@ With index 0 only the first type is shown:
       "line": 1,
       "col": 16
     },
-    "type": 1,
+    "type": "(int -> int) -> int list -> int list",
     "tail": "no"
   }
 
@@ -183,21 +183,9 @@ next type was not rendered.
         },
         "end": {
           "line": 2,
-          "col": 16
-        },
-        "type": 1,
-        "tail": "no"
-      },
-      {
-        "start": {
-          "line": 2,
-          "col": 8
-        },
-        "end": {
-          "line": 2,
           "col": 27
         },
-        "type": 2,
+        "type": 1,
         "tail": "no"
       }
     ],
@@ -232,7 +220,7 @@ should have been shorter earlier.
           "line": 2,
           "col": 27
         },
-        "type": 2,
+        "type": "int list",
         "tail": "no"
       }
     ],

--- a/tests/test-dirs/type-enclosing/generic-types.t
+++ b/tests/test-dirs/type-enclosing/generic-types.t
@@ -1,0 +1,240 @@
+  $ cat >main.ml <<'EOF'
+  > let _ = List.map Fun.id [3]
+  > EOF
+
+With index 0 only the first type is shown:
+  $ $MERLIN single type-enclosing -position 1:14 -index 0 \
+  > -filename ./main.ml < ./main.ml | jq '.value[0,1]'
+  {
+    "start": {
+      "line": 1,
+      "col": 8
+    },
+    "end": {
+      "line": 1,
+      "col": 16
+    },
+    "type": "('a -> 'b) -> 'a list -> 'b list",
+    "tail": "no"
+  }
+  {
+    "start": {
+      "line": 1,
+      "col": 8
+    },
+    "end": {
+      "line": 1,
+      "col": 16
+    },
+    "type": 1,
+    "tail": "no"
+  }
+
+With index 1 only the second is shown (the first is a string so it is always shown):
+  $ $MERLIN single type-enclosing -position 1:14 -index 1 \
+  > -filename ./main.ml < ./main.ml  | jq '.value[0,1]'
+  {
+    "start": {
+      "line": 1,
+      "col": 8
+    },
+    "end": {
+      "line": 1,
+      "col": 16
+    },
+    "type": "('a -> 'b) -> 'a list -> 'b list",
+    "tail": "no"
+  }
+  {
+    "start": {
+      "line": 1,
+      "col": 8
+    },
+    "end": {
+      "line": 1,
+      "col": 16
+    },
+    "type": "(int -> int) -> int list -> int list",
+    "tail": "no"
+  }
+
+
+With index 0 only the first type is shown:
+  $ $MERLIN single type-enclosing -position 1:10 -index 0 \
+  > -filename ./main.ml < ./main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 12
+        },
+        "type": "(module Stdlib__List)",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 16
+        },
+        "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 27
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+With index 1 only the second is shown (the first is a string so it is always shown):
+FIXME? We don't see the generic version
+  $ $MERLIN single type-enclosing -position 1:10 -index 1 \
+  > -filename ./main.ml < ./main.ml 
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 12
+        },
+        "type": "(module Stdlib__List)",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 1,
+          "col": 8
+        },
+        "end": {
+          "line": 1,
+          "col": 27
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+  $ cat >main.ml <<'EOF'
+  > module List = struct let map : (int -> int) -> int list -> int list = List.map end
+  > let _ = List.map Fun.id [3]
+  > EOF
+
+FIXME With index 0 only the first type is shown but deduplication failed becauser the
+next type was not rendered.
+  $ $MERLIN single type-enclosing -position 2:14 -index 0 \
+  > -filename ./main.ml < ./main.ml 
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 27
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+FIXME With index 1 the list is shorter and the numbering is wrong ! In fact, it
+should have been shorter earlier.
+  $ $MERLIN single type-enclosing -position 2:14 -index 1 \
+  > -filename ./main.ml < ./main.ml 
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 27
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/type-enclosing/generic-types.t
+++ b/tests/test-dirs/type-enclosing/generic-types.t
@@ -26,7 +26,7 @@ With index 0 only the first type is shown:
       "line": 1,
       "col": 16
     },
-    "type": "(int -> int) -> int list -> int list",
+    "type": 1,
     "tail": "no"
   }
 
@@ -107,7 +107,7 @@ With index 0 only the first type is shown:
 
 With index 1 only the second is shown (the first is a string so it is always shown):
 FIXME? We don't see the generic version
-  $ $MERLIN single type-enclosing -position 1:10 -index 1 \
+  $ $MERLIN single type-enclosing -short-paths -position 1:10 -index 1 \
   > -filename ./main.ml < ./main.ml 
   {
     "class": "return",
@@ -121,7 +121,7 @@ FIXME? We don't see the generic version
           "line": 1,
           "col": 12
         },
-        "type": "(module Stdlib__List)",
+        "type": "(module List)",
         "tail": "no"
       },
       {
@@ -157,7 +157,8 @@ FIXME? We don't see the generic version
   > let _ = List.map Fun.id [3]
   > EOF
 
-With index 0 only the first type is shown and deduplication id working
+With index 0 only the first type is shown. The next enclosing is not
+deduplicated as intended, this should be done by the client.
   $ $MERLIN single type-enclosing -position 2:14 -index 0 \
   > -filename ./main.ml < ./main.ml 
   {
@@ -182,9 +183,21 @@ With index 0 only the first type is shown and deduplication id working
         },
         "end": {
           "line": 2,
-          "col": 27
+          "col": 16
         },
         "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 27
+        },
+        "type": 2,
         "tail": "no"
       }
     ],
@@ -216,17 +229,29 @@ And with index=1 the correct type is shown
         },
         "end": {
           "line": 2,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
           "col": 27
         },
-        "type": "int list",
+        "type": 2,
         "tail": "no"
       }
     ],
     "notifications": []
   }
 
-And with index>=2 Merlin sticks to the last item
-  $ $MERLIN single type-enclosing -position 2:14 -index 2 \
+And with index>=3 Merlin sticks to the last item
+  $ $MERLIN single type-enclosing -position 2:14 -index 7 \
   > -filename ./main.ml < ./main.ml 
   {
     "class": "return",
@@ -241,6 +266,18 @@ And with index>=2 Merlin sticks to the last item
           "col": 16
         },
         "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": 1,
         "tail": "no"
       },
       {

--- a/tests/test-dirs/type-enclosing/generic-types.t
+++ b/tests/test-dirs/type-enclosing/generic-types.t
@@ -157,8 +157,7 @@ FIXME? We don't see the generic version
   > let _ = List.map Fun.id [3]
   > EOF
 
-FIXME With index 0 only the first type is shown but deduplication failed becauser the
-next type was not rendered.
+With index 0 only the first type is shown and deduplication id working
   $ $MERLIN single type-enclosing -position 2:14 -index 0 \
   > -filename ./main.ml < ./main.ml 
   {
@@ -192,9 +191,42 @@ next type was not rendered.
     "notifications": []
   }
 
-FIXME With index 1 the list is shorter and the numbering is wrong ! In fact, it
-should have been shorter earlier.
+And with index=1 the correct type is shown
   $ $MERLIN single type-enclosing -position 2:14 -index 1 \
+  > -filename ./main.ml < ./main.ml 
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 16
+        },
+        "type": "(int -> int) -> int list -> int list",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 8
+        },
+        "end": {
+          "line": 2,
+          "col": 27
+        },
+        "type": "int list",
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+And with index>=2 Merlin sticks to the last item
+  $ $MERLIN single type-enclosing -position 2:14 -index 2 \
   > -filename ./main.ml < ./main.ml 
   {
     "class": "return",

--- a/tests/test-dirs/type-enclosing/github1003.t/run.t
+++ b/tests/test-dirs/type-enclosing/github1003.t/run.t
@@ -12,6 +12,18 @@
       },
       "type": "int",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 5,
+        "col": 8
+      },
+      "end": {
+        "line": 5,
+        "col": 16
+      },
+      "type": "int",
+      "tail": "no"
     }
   ]
 

--- a/tests/test-dirs/type-enclosing/issue1477.t
+++ b/tests/test-dirs/type-enclosing/issue1477.t
@@ -26,6 +26,18 @@
       },
       "end": {
         "line": 2,
+        "col": 9
+      },
+      "type": "int -> int",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 2,
+        "col": 8
+      },
+      "end": {
+        "line": 2,
         "col": 11
       },
       "type": "int",

--- a/tests/test-dirs/type-enclosing/letop.t/run.t
+++ b/tests/test-dirs/type-enclosing/letop.t/run.t
@@ -86,9 +86,9 @@ Various parts of the letop:
       },
       "end": {
         "line": 4,
-        "col": 37
+        "col": 29
       },
-      "type": "'a option",
+      "type": "('a, 'b) Hashtbl.t -> 'a -> 'b option",
       "tail": "no"
     }
   ]
@@ -111,13 +111,13 @@ Various parts of the letop:
     {
       "start": {
         "line": 4,
-        "col": 13
+        "col": 30
       },
       "end": {
         "line": 4,
-        "col": 37
+        "col": 33
       },
-      "type": "'a option",
+      "type": "('a, 'b) Hashtbl.t",
       "tail": "no"
     }
   ]
@@ -140,13 +140,13 @@ Various parts of the letop:
     {
       "start": {
         "line": 4,
-        "col": 13
+        "col": 34
       },
       "end": {
         "line": 4,
         "col": 37
       },
-      "type": "'a option",
+      "type": "'a",
       "tail": "no"
     }
   ]
@@ -175,7 +175,7 @@ Various parts of the letop:
       },
       "end": {
         "line": 5,
-        "col": 9
+        "col": 5
       },
       "type": "int",
       "tail": "no"

--- a/tests/test-dirs/type-enclosing/mod-type.t/run.t
+++ b/tests/test-dirs/type-enclosing/mod-type.t/run.t
@@ -43,6 +43,18 @@ Get the type of a module type with the same name as a module:
       },
       "type": "sig type a end",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 5,
+        "col": 8
+      },
+      "end": {
+        "line": 5,
+        "col": 9
+      },
+      "type": "sig type a end",
+      "tail": "no"
     }
   ]
 
@@ -64,7 +76,7 @@ Get the type of a module type with the same name as a module:
     {
       "start": {
         "line": 7,
-        "col": 8
+        "col": 23
       },
       "end": {
         "line": 7,
@@ -93,7 +105,7 @@ Get the type of a module type with the same name as a module:
     {
       "start": {
         "line": 7,
-        "col": 8
+        "col": 23
       },
       "end": {
         "line": 7,

--- a/tests/test-dirs/type-enclosing/objects.t/run.t
+++ b/tests/test-dirs/type-enclosing/objects.t/run.t
@@ -112,9 +112,9 @@
       },
       "end": {
         "line": 14,
-        "col": 14
+        "col": 9
       },
-      "type": "int -> unit",
+      "type": "< pop : int option; push : int -> unit >",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/type-enclosing/record.t/run.t
+++ b/tests/test-dirs/type-enclosing/record.t/run.t
@@ -95,9 +95,9 @@
       },
       "end": {
         "line": 8,
-        "col": 17
+        "col": 9
       },
-      "type": "unit",
+      "type": "t",
       "tail": "no"
     }
   ]
@@ -124,9 +124,9 @@
       },
       "end": {
         "line": 8,
-        "col": 17
+        "col": 9
       },
-      "type": "type unit = ()",
+      "type": "type t = { mutable b : float; }",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/type-enclosing/te-413-features.t
+++ b/tests/test-dirs/type-enclosing/te-413-features.t
@@ -21,13 +21,13 @@ Named existentials in patterns
     {
       "start": {
         "line": 3,
-        "col": 51
+        "col": 59
       },
       "end": {
         "line": 3,
-        "col": 65
+        "col": 60
       },
-      "type": "unit",
+      "type": "a",
       "tail": "no"
     }
   ]

--- a/tests/test-dirs/type-enclosing/te-modules.t
+++ b/tests/test-dirs/type-enclosing/te-modules.t
@@ -1,0 +1,238 @@
+  $ cat >main.ml <<'EOF'
+  > module M = struct module N = struct let x = () let y = () end end
+  > module B = M.N
+  > EOF
+
+With index 0 only the first type is shown:
+  $ $MERLIN single type-enclosing -position 2:7 -verbosity 0 -index 0 \
+  > -filename ./main.ml < ./main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 7
+        },
+        "end": {
+          "line": 2,
+          "col": 8
+        },
+        "type": "(module M.N)",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 0
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 1,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single type-enclosing -position 2:7 -verbosity 1 -index 0 \
+  > -filename ./main.ml < ./main.ml
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 7
+        },
+        "end": {
+          "line": 2,
+          "col": 8
+        },
+        "type": "sig val x : unit val y : unit end",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 0
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 1,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+  $ cat >main.ml <<'EOF'
+  > module M = struct module N = List end
+  > module B = M.N
+  > EOF
+
+With index 0 only the first type is shown:
+  $ $MERLIN single type-enclosing -position 2:13 -verbosity 0 -index 0 \
+  > -filename ./main.ml < ./main.ml  
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 11
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": "(module List)",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 11
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 0
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }
+
+  $ $MERLIN single type-enclosing -position 2:13 -verbosity 1 -index 0 \
+  > -filename ./main.ml < ./main.ml  
+  {
+    "class": "return",
+    "value": [
+      {
+        "start": {
+          "line": 2,
+          "col": 11
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": "sig
+    type 'a t = 'a list = [] | (::) of 'a * 'a list
+    val length : 'a list -> int
+    val compare_lengths : 'a list -> 'b list -> int
+    val compare_length_with : 'a list -> int -> int
+    val is_empty : 'a list -> bool
+    val cons : 'a -> 'a list -> 'a list
+    val hd : 'a list -> 'a
+    val tl : 'a list -> 'a list
+    val nth : 'a list -> int -> 'a
+    val nth_opt : 'a list -> int -> 'a option
+    val rev : 'a list -> 'a list
+    val init : int -> (int -> 'a) -> 'a list
+    val append : 'a list -> 'a list -> 'a list
+    val rev_append : 'a list -> 'a list -> 'a list
+    val concat : 'a list list -> 'a list
+    val flatten : 'a list list -> 'a list
+    val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+    val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
+    val iter : ('a -> unit) -> 'a list -> unit
+    val iteri : (int -> 'a -> unit) -> 'a list -> unit
+    val map : ('a -> 'b) -> 'a list -> 'b list
+    val mapi : (int -> 'a -> 'b) -> 'a list -> 'b list
+    val rev_map : ('a -> 'b) -> 'a list -> 'b list
+    val filter_map : ('a -> 'b option) -> 'a list -> 'b list
+    val concat_map : ('a -> 'b list) -> 'a list -> 'b list
+    val fold_left_map :
+      ('acc -> 'a -> 'acc * 'b) -> 'acc -> 'a list -> 'acc * 'b list
+    val fold_left : ('acc -> 'a -> 'acc) -> 'acc -> 'a list -> 'acc
+    val fold_right : ('a -> 'acc -> 'acc) -> 'a list -> 'acc -> 'acc
+    val iter2 : ('a -> 'b -> unit) -> 'a list -> 'b list -> unit
+    val map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+    val rev_map2 : ('a -> 'b -> 'c) -> 'a list -> 'b list -> 'c list
+    val fold_left2 :
+      ('acc -> 'a -> 'b -> 'acc) -> 'acc -> 'a list -> 'b list -> 'acc
+    val fold_right2 :
+      ('a -> 'b -> 'acc -> 'acc) -> 'a list -> 'b list -> 'acc -> 'acc
+    val for_all : ('a -> bool) -> 'a list -> bool
+    val exists : ('a -> bool) -> 'a list -> bool
+    val for_all2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+    val exists2 : ('a -> 'b -> bool) -> 'a list -> 'b list -> bool
+    val mem : 'a -> 'a list -> bool
+    val memq : 'a -> 'a list -> bool
+    val find : ('a -> bool) -> 'a list -> 'a
+    val find_opt : ('a -> bool) -> 'a list -> 'a option
+    val find_index : ('a -> bool) -> 'a list -> int option
+    val find_map : ('a -> 'b option) -> 'a list -> 'b option
+    val find_mapi : (int -> 'a -> 'b option) -> 'a list -> 'b option
+    val filter : ('a -> bool) -> 'a list -> 'a list
+    val find_all : ('a -> bool) -> 'a list -> 'a list
+    val filteri : (int -> 'a -> bool) -> 'a list -> 'a list
+    val partition : ('a -> bool) -> 'a list -> 'a list * 'a list
+    val partition_map :
+      ('a -> ('b, 'c) Either.t) -> 'a list -> 'b list * 'c list
+    val assoc : 'a -> ('a * 'b) list -> 'b
+    val assoc_opt : 'a -> ('a * 'b) list -> 'b option
+    val assq : 'a -> ('a * 'b) list -> 'b
+    val assq_opt : 'a -> ('a * 'b) list -> 'b option
+    val mem_assoc : 'a -> ('a * 'b) list -> bool
+    val mem_assq : 'a -> ('a * 'b) list -> bool
+    val remove_assoc : 'a -> ('a * 'b) list -> ('a * 'b) list
+    val remove_assq : 'a -> ('a * 'b) list -> ('a * 'b) list
+    val split : ('a * 'b) list -> 'a list * 'b list
+    val combine : 'a list -> 'b list -> ('a * 'b) list
+    val sort : ('a -> 'a -> int) -> 'a list -> 'a list
+    val stable_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+    val fast_sort : ('a -> 'a -> int) -> 'a list -> 'a list
+    val sort_uniq : ('a -> 'a -> int) -> 'a list -> 'a list
+    val merge : ('a -> 'a -> int) -> 'a list -> 'a list -> 'a list
+    val to_seq : 'a list -> 'a Seq.t
+    val of_seq : 'a Seq.t -> 'a list
+  end",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 11
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 1,
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 0
+        },
+        "end": {
+          "line": 2,
+          "col": 14
+        },
+        "type": 2,
+        "tail": "no"
+      }
+    ],
+    "notifications": []
+  }

--- a/tests/test-dirs/type-enclosing/types.t/run.t
+++ b/tests/test-dirs/type-enclosing/types.t/run.t
@@ -53,18 +53,6 @@
       },
       "type": "type x = Foo",
       "tail": "no"
-    },
-    {
-      "start": {
-        "line": 5,
-        "col": 10
-      },
-      "end": {
-        "line": 5,
-        "col": 11
-      },
-      "type": "type x = Foo",
-      "tail": "no"
     }
   ]
 

--- a/tests/test-dirs/type-enclosing/types.t/run.t
+++ b/tests/test-dirs/type-enclosing/types.t/run.t
@@ -53,6 +53,18 @@
       },
       "type": "type x = Foo",
       "tail": "no"
+    },
+    {
+      "start": {
+        "line": 5,
+        "col": 10
+      },
+      "end": {
+        "line": 5,
+        "col": 11
+      },
+      "type": "type x = Foo",
+      "tail": "no"
     }
   ]
 

--- a/tests/test-dirs/type-enclosing/underscore-ids.t
+++ b/tests/test-dirs/type-enclosing/underscore-ids.t
@@ -30,6 +30,18 @@ in the presence of underscores.
         "line": 3,
         "col": 6
       },
+      "type": "float",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 2
+      },
+      "end": {
+        "line": 3,
+        "col": 6
+      },
       "type": "int",
       "tail": "no"
     },
@@ -55,6 +67,18 @@ in the presence of underscores.
   >   _foo
   > EOF
   [
+    {
+      "start": {
+        "line": 3,
+        "col": 2
+      },
+      "end": {
+        "line": 3,
+        "col": 6
+      },
+      "type": "float",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 3,
@@ -123,6 +147,18 @@ We try several places in the identifier to check the result stability
         "line": 3,
         "col": 9
       },
+      "type": "float",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 2
+      },
+      "end": {
+        "line": 3,
+        "col": 9
+      },
       "type": "int",
       "tail": "no"
     },
@@ -148,6 +184,18 @@ We try several places in the identifier to check the result stability
   >   foo_bar
   > EOF
   [
+    {
+      "start": {
+        "line": 3,
+        "col": 2
+      },
+      "end": {
+        "line": 3,
+        "col": 9
+      },
+      "type": "float",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 3,
@@ -215,6 +263,18 @@ We try several places in the identifier to check the result stability
         "line": 3,
         "col": 9
       },
+      "type": "float",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 3,
+        "col": 2
+      },
+      "end": {
+        "line": 3,
+        "col": 9
+      },
       "type": "int",
       "tail": "no"
     },
@@ -241,6 +301,18 @@ We try several places in the identifier to check the result stability
   {
     "class": "return",
     "value": [
+      {
+        "start": {
+          "line": 3,
+          "col": 2
+        },
+        "end": {
+          "line": 3,
+          "col": 9
+        },
+        "type": "float",
+        "tail": "no"
+      },
       {
         "start": {
           "line": 3,
@@ -314,6 +386,18 @@ We try several places in the identifier to check the result stability
           "col": 12
         },
         "type": "int option",
+        "tail": "no"
+      },
+      {
+        "start": {
+          "line": 2,
+          "col": 18
+        },
+        "end": {
+          "line": 5,
+          "col": 17
+        },
+        "type": "int option -> int",
         "tail": "no"
       },
       {

--- a/tests/test-dirs/type-enclosing/underscore-ids.t
+++ b/tests/test-dirs/type-enclosing/underscore-ids.t
@@ -325,18 +325,6 @@ We try several places in the identifier to check the result stability
           "line": 5,
           "col": 17
         },
-        "type": "int option -> int",
-        "tail": "no"
-      },
-      {
-        "start": {
-          "line": 2,
-          "col": 18
-        },
-        "end": {
-          "line": 5,
-          "col": 17
-        },
         "type": "'a",
         "tail": "no"
       },

--- a/tests/test-dirs/type-enclosing/variants.t/run.t
+++ b/tests/test-dirs/type-enclosing/variants.t/run.t
@@ -155,8 +155,32 @@
 
 FIXME: Not satisfying, expected core not more
   $ $MERLIN single type-enclosing -position 9:3 -verbosity 0 \
-  > -filename ./variants.ml < ./variants.ml | jq ".value[0:2]"
+  > -filename ./variants.ml < ./variants.ml | jq ".value"
   [
+    {
+      "start": {
+        "line": 9,
+        "col": 2
+      },
+      "end": {
+        "line": 9,
+        "col": 7
+      },
+      "type": "more",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 9,
+        "col": 2
+      },
+      "end": {
+        "line": 9,
+        "col": 7
+      },
+      "type": "more",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 9,
@@ -184,8 +208,32 @@ FIXME: Not satisfying, expected core not more
   ]
 
   $ $MERLIN single type-enclosing -position 9:3 -verbosity 1 \
-  > -filename ./variants.ml < ./variants.ml | jq ".value[0:2]"
+  > -filename ./variants.ml < ./variants.ml | jq ".value"
   [
+    {
+      "start": {
+        "line": 9,
+        "col": 2
+      },
+      "end": {
+        "line": 9,
+        "col": 7
+      },
+      "type": "[ `A | `B | `C ]",
+      "tail": "no"
+    },
+    {
+      "start": {
+        "line": 9,
+        "col": 2
+      },
+      "end": {
+        "line": 9,
+        "col": 7
+      },
+      "type": "[ `A | `B | `C ]",
+      "tail": "no"
+    },
     {
       "start": {
         "line": 9,


### PR DESCRIPTION
This PR backports upstream pr https://github.com/ocaml/merlin/pull/1864, which fixes some behavior in the `type-enclosing` query. By default, `type-enclosing` returns a list of results, corresponding to nodes enclosing the given position with expanding ranges. For example, if you run `type-enclosing` on `Some (x + 1)` with the cursor on `x`, you will get results corresponding to the expressions `x`, `x + 1`, and `Some (x + 1)`.

Printing types is expensive, so Merlin offers a parameter `-index` to `type-enclosing` that allows you to only request the nth element of that list. Thus, editors can start by requesting only the innermost result and then progressively increase the range as a user requests to.

But the current implementation has a problem. Merlin has some logic to deduplicate results, but the logic is partially based on the types that are printed. Since Merlin will only print types for the requested index(es), the deduplication is based on what index is requested. This means that the list changes out from under you as you attempt to increase the range. This has caused bad behavior in emacs.

The upstream PR that this backports makes deduplication stable by not relying on printing. As a consequence, results are sometimes duplicated, and it is left to the client (which can maintain state between queries, unlike Merlin) to deduplicate them.

But after this upstream PR, Merlin still deduplicates results based on the ranges of the corresponding nodes. Nodes may sometimes have the same range, and I argue that if two nodes have the same range:
- If they give the same type, we've already delegated deduplication to clients, so we should make them deduplicate this case too.
- If they have different types, this is interesting information and we should display it. Based on Merlin's test suite, it seems that the only case where this happens is when there is a type error. In this case, one of the nodes has the actual type of the expression, and the other has the expected type.

So this PR also makes the change such that we never deduplicate results. The short-term consequence of this (until we update clients to perform deduplication) will be that users sometimes see duplicate results. But this seems better than the current state of the world, which is that progressively expanding the range will frequently fail.

I've discussed this with JS lsp folks and they are on board with this change.

## Reviewing

- The first four commits backport PR 1864.
- The next commit (4a5aed128ced21777c25c888dbdd74d8df79feb1) promotes tests that changed as a result of backporting that PR.
- The last commit (e22f3e08857c0df979e1bcf137dddb1dce24080c) stops deduplication on the basis of location.