### PR TITLE
Put `Compl.kind` and `Locate_context.t` in `query_protocol_kernel`

### DIFF
--- a/merlin-lib.opam
+++ b/merlin-lib.opam
@@ -17,6 +17,8 @@ depends: [
   "menhir"    {dev & = "20231231"}
   "menhirLib" {dev & = "20231231"}
   "menhirSdk" {dev & = "20231231"}
+  "yojson" {>= "2.0.0"}
+  "ppx_yojson_conv" {>= "0.17.0"}
 ]
 synopsis:
   "Merlin's libraries"

--- a/merlin-lib.opam
+++ b/merlin-lib.opam
@@ -19,6 +19,7 @@ depends: [
   "menhirSdk" {dev & = "20231231"}
   "yojson" {>= "2.0.0"}
   "ppx_yojson_conv" {>= "0.17.0"}
+  "ppx_jane" {>= "0.17.0"}
 ]
 synopsis:
   "Merlin's libraries"

--- a/merlin.opam
+++ b/merlin.opam
@@ -16,7 +16,6 @@ depends: [
   "merlin-lib" {= version}
   "dot-merlin-reader" {>= "5.0"}
   "ocaml-index" {>= "1.0" & post}
-  "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
   "ppxlib" {with-test}
 ]

--- a/src/analysis/dune
+++ b/src/analysis/dune
@@ -23,6 +23,7 @@
   ocaml_parsing
   ocaml_preprocess
   query_protocol
+  query_protocol_kernel
   ocaml_typing
   ocaml_utils
   str

--- a/src/analysis/locate_type_multi.ml
+++ b/src/analysis/locate_type_multi.ml
@@ -1,0 +1,46 @@
+open StdLabels
+
+module Type_tree = struct
+  type node_data =
+    | Arrow
+    | Tuple
+    | Object
+    | Type_ref of { path : Path.t; ty : Types.type_expr }
+
+  type t = { data : node_data; children : t list }
+end
+
+let rec flatten_arrow ret_ty =
+  match Types.get_desc ret_ty with
+  | Tarrow (_, ty1, ty2, _) -> ty1 :: flatten_arrow ty2
+  | _ -> [ ret_ty ]
+
+let rec create_type_tree ty : Type_tree.t option =
+  match Types.get_desc ty with
+  | Tarrow (_, ty1, ty2, _) ->
+    let tys = ty1 :: flatten_arrow ty2 in
+    let children = List.filter_map tys ~f:create_type_tree in
+    Some { data = Arrow; children }
+  | Ttuple tys | Tunboxed_tuple tys ->
+    let children =
+      List.filter_map tys ~f:(fun (_, ty) -> create_type_tree ty)
+    in
+    Some { data = Tuple; children }
+  | Tconstr (path, arg_tys, abbrev_memo) ->
+    let ty_without_args =
+      Types.newty2 ~level:Ident.highest_scope (Tconstr (path, [], abbrev_memo))
+    in
+    let children = List.filter_map arg_tys ~f:create_type_tree in
+    Some { data = Type_ref { path; ty = ty_without_args }; children }
+  | Tlink ty | Tpoly (ty, _) -> create_type_tree ty
+  | Tobject (fields_type, _) ->
+    let rec extract_field_types (ty : Types.type_expr) =
+      match Types.get_desc ty with
+      | Tfield (_, _, ty, rest) -> ty :: extract_field_types rest
+      | _ -> []
+    in
+    let field_types = List.rev (extract_field_types fields_type) in
+    let children = List.filter_map field_types ~f:create_type_tree in
+    Some { data = Object; children }
+  | Tnil | Tvar _ | Tsubst _ | Tvariant _ | Tunivar _ | Tpackage _ | Tfield _ ->
+    None

--- a/src/analysis/locate_type_multi.mli
+++ b/src/analysis/locate_type_multi.mli
@@ -1,0 +1,11 @@
+module Type_tree : sig
+  type node_data =
+    | Arrow
+    | Tuple
+    | Object
+    | Type_ref of { path : Path.t; ty : Types.type_expr }
+
+  type t = { data : node_data; children : t list }
+end
+
+val create_type_tree : Types.type_expr -> Type_tree.t option

--- a/src/commands/dune
+++ b/src/commands/dune
@@ -12,5 +12,8 @@
     merlin-lib.utils
     merlin-lib.kernel
     merlin-lib.query_protocol
+    merlin-lib.query_protocol_kernel
     merlin-lib.query_commands
-    merlin-lib.ocaml_utils))
+    merlin-lib.ocaml_utils
+    yojson)
+  (preprocess (pps ppx_yojson_conv)))

--- a/src/commands/new_commands.ml
+++ b/src/commands/new_commands.ml
@@ -513,6 +513,23 @@ let all_commands =
           | #Msource.position as pos ->
             run buffer (Query_protocol.Locate_type pos)
       end;
+    command "locate-type-multi"
+      ~spec:
+        [ arg "-position" "<position> Position to locate the type of"
+            (marg_position (fun pos _ -> pos))
+        ]
+      ~doc:
+        "Locate the declaration of the type of the expression. If the type is \
+         expressed via multiple identifiers, it returns the location of each \
+         identifier."
+      ~default:`None
+      begin
+        fun buffer pos ->
+          match pos with
+          | `None -> failwith "-position <pos> is mandatory"
+          | #Msource.position as pos ->
+            run buffer (Query_protocol.Locate_type_multi pos)
+      end;
     command "occurrences"
       ~spec:
         [ arg "-identifier-at" "<position> Position of the identifier"

--- a/src/commands/new_commands.ml
+++ b/src/commands/new_commands.ml
@@ -480,9 +480,8 @@ let all_commands =
                 "<%s> Which context to search for the identifier in" contexts)
              (Marg.param (Format.sprintf "<%s>" contexts)
                 (fun ctx (prefix, pos, kind, _) ->
-                  match Query_protocol.Locate_context.of_string ctx with
-                  | Some ctx -> (prefix, pos, kind, Some ctx)
-                  | None -> failwithf "invalid context %s." ctx)))
+                  let ctx = Query_protocol.Locate_context.of_string ctx in
+                  (prefix, pos, kind, Some ctx))))
         ]
       ~doc:
         "Finds the declaration of entity at the specified position, Or \

--- a/src/commands/query_json.ml
+++ b/src/commands/query_json.ml
@@ -39,18 +39,7 @@ let dump (type a) : a t -> json =
       `Assoc [ ("line", `Int line); ("column", `Int col) ]
   in
   let kinds_to_json kind =
-    `List
-      (List.map
-         ~f:(function
-           | `Constructor -> `String "constructor"
-           | `Keywords -> `String "keywords"
-           | `Labels -> `String "label"
-           | `Modules -> `String "module"
-           | `Modules_type -> `String "module-type"
-           | `Types -> `String "type"
-           | `Values -> `String "value"
-           | `Variants -> `String "variant")
-         kind)
+    `List (List.map ~f:(fun kind -> `String (Compl.Kind.to_string kind)) kind)
   in
   function
   | Type_expr (expr, pos) ->

--- a/src/commands/query_json.ml
+++ b/src/commands/query_json.ml
@@ -79,6 +79,8 @@ let dump (type a) : a t -> json =
         ("position", mk_position pos)
       ]
   | Locate_type pos -> mk "locate-type" [ ("position", mk_position pos) ]
+  | Locate_type_multi pos ->
+    mk "locate-type-multi" [ ("position", mk_position pos) ]
   | Enclosing pos -> mk "enclosing" [ ("position", mk_position pos) ]
   | Complete_prefix (prefix, pos, kind, doc, typ) ->
     mk "complete-prefix"
@@ -474,6 +476,8 @@ let json_of_response (type a) (query : a t) (response : a) : json =
     in
     str
   | Locate_type _, resp -> json_of_locate resp
+  | Locate_type_multi _, resp ->
+    Json.of_yojson_safe (Locate_type_multi_result.yojson_of_t resp)
   | Locate _, resp -> json_of_locate resp
   | Jump _, resp -> begin
     match resp with

--- a/src/frontend/dune
+++ b/src/frontend/dune
@@ -2,8 +2,8 @@
  (name        query_protocol)
  (public_name merlin-lib.query_protocol)
  (modules     query_protocol)
- (flags :standard -open Merlin_utils -open Merlin_kernel -open Ocaml_parsing -open Ocaml_utils)
- (libraries merlin_kernel merlin_utils ocaml_parsing ocaml_utils))
+ (flags :standard -open Merlin_utils -open Merlin_kernel -open Ocaml_parsing -open Ocaml_utils -open Query_protocol_kernel)
+ (libraries merlin_kernel merlin_utils ocaml_parsing ocaml_utils query_protocol_kernel))
 
 (library
  (name        query_commands)
@@ -32,4 +32,5 @@
   merlin_analysis
   merlin_sherlodoc
   query_protocol
+  query_protocol_kernel
   str))

--- a/src/frontend/kernel/completion_kind.ml
+++ b/src/frontend/kernel/completion_kind.ml
@@ -1,0 +1,30 @@
+type t =
+  [ `Constructor
+  | `Labels
+  | `Modules
+  | `Modules_type
+  | `Types
+  | `Values
+  | `Variants
+  | `Keywords ]
+
+let to_string = function
+  | `Constructor -> "constructor"
+  | `Keywords -> "keywords"
+  | `Labels -> "label"
+  | `Modules -> "module"
+  | `Modules_type -> "module-type"
+  | `Types -> "type"
+  | `Values -> "value"
+  | `Variants -> "variant"
+
+let of_string_opt = function
+  | "t" | "type" | "types" -> Some `Types
+  | "v" | "val" | "value" | "values" -> Some `Values
+  | "variant" | "variants" | "var" -> Some `Variants
+  | "c" | "constr" | "constructor" -> Some `Constructor
+  | "l" | "label" | "labels" -> Some `Labels
+  | "m" | "mod" | "module" -> Some `Modules
+  | "mt" | "modtype" | "module-type" -> Some `Modules_type
+  | "k" | "kw" | "keyword" | "keywords" -> Some `Keywords
+  | _ -> None

--- a/src/frontend/kernel/completion_kind.mli
+++ b/src/frontend/kernel/completion_kind.mli
@@ -1,0 +1,12 @@
+type t =
+  [ `Constructor
+  | `Labels
+  | `Modules
+  | `Modules_type
+  | `Types
+  | `Values
+  | `Variants
+  | `Keywords ]
+
+val to_string : t -> string
+val of_string_opt : string -> t option

--- a/src/frontend/kernel/dune
+++ b/src/frontend/kernel/dune
@@ -2,4 +2,4 @@
  (name        query_protocol_kernel)
  (public_name merlin-lib.query_protocol_kernel)
  (libraries yojson)
- (preprocess (pps ppx_yojson_conv)))
+ (preprocess (pps ppx_jane ppx_yojson_conv)))

--- a/src/frontend/kernel/dune
+++ b/src/frontend/kernel/dune
@@ -1,0 +1,5 @@
+(library
+ (name        query_protocol_kernel)
+ (public_name merlin-lib.query_protocol_kernel)
+ (libraries yojson)
+ (preprocess (pps ppx_yojson_conv)))

--- a/src/frontend/kernel/locate_context.ml
+++ b/src/frontend/kernel/locate_context.ml
@@ -1,0 +1,11 @@
+type t =
+  | Expr [@rename "expr"]
+  | Module_path [@rename "module_path"]
+  | Module_type [@rename "module_type"]
+  | Patt [@rename "pattern"]
+  | Type [@rename "type"]
+  | Constant [@rename "constant"]
+  | Constructor [@rename "constructor"]
+  | Label [@rename "label"]
+  | Unknown [@rename "unknown"]
+[@@deriving string ~case_insensitive, enumerate]

--- a/src/frontend/kernel/locate_context.mli
+++ b/src/frontend/kernel/locate_context.mli
@@ -1,0 +1,11 @@
+type t =
+  | Expr
+  | Module_path
+  | Module_type
+  | Patt
+  | Type
+  | Constant
+  | Constructor
+  | Label
+  | Unknown
+[@@deriving string, enumerate]

--- a/src/frontend/kernel/locate_type_multi_result.ml
+++ b/src/frontend/kernel/locate_type_multi_result.ml
@@ -1,0 +1,33 @@
+(* This module contains definitions that can be used in a js-of-ocaml environment. This
+   is useful because it allows VSCode extensions (which run in javascript) to use the
+   serializers/deserializers defined in this module. *)
+
+open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+module Lexing = struct
+  include Lexing
+
+  type nonrec position = position =
+    { pos_fname : string; pos_lnum : int; pos_bol : int; pos_cnum : int }
+  [@@deriving yojson]
+end
+
+type node_data =
+  | Arrow
+  | Tuple
+  | Object
+  | Type_ref of
+      { type_ : string;
+        result :
+          [ `Found of string option * Lexing.position
+          | `Builtin of string
+          | `Not_in_env of string
+          | `File_not_found of string
+          | `Not_found of string * string option ]
+      }
+[@@deriving yojson]
+
+type type_tree = { data : node_data; children : type_tree list }
+[@@deriving yojson]
+
+type t = Success of type_tree | Invalid_context [@@deriving yojson]

--- a/src/frontend/kernel/locate_type_multi_result.mli
+++ b/src/frontend/kernel/locate_type_multi_result.mli
@@ -1,0 +1,19 @@
+type node_data =
+  | Arrow
+  | Tuple
+  | Object
+  | Type_ref of
+      { type_ : string;
+        result :
+          [ `Found of string option * Lexing.position
+          | `Builtin of string
+          | `Not_in_env of string
+          | `File_not_found of string
+          | `Not_found of string * string option ]
+      }
+[@@deriving yojson]
+
+type type_tree = { data : node_data; children : type_tree list }
+[@@deriving yojson]
+
+type t = Success of type_tree | Invalid_context [@@deriving yojson]

--- a/src/frontend/kernel/query_protocol_kernel.ml
+++ b/src/frontend/kernel/query_protocol_kernel.ml
@@ -1,0 +1,39 @@
+(* This module contains definitions that can be used in a js-of-ocaml environment. This
+   is useful because it allows VSCode extensions (which run in javascript) to use the
+   serializers/deserializers defined in this module. *)
+
+open struct
+  include Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+  module Lexing = struct
+    include Lexing
+
+    type nonrec position = position =
+      { pos_fname : string; pos_lnum : int; pos_bol : int; pos_cnum : int }
+    [@@deriving yojson]
+  end
+end
+
+module Locate_type_multi_result = struct
+  open Ppx_yojson_conv_lib.Yojson_conv.Primitives
+
+  type node_data =
+    | Arrow
+    | Tuple
+    | Object
+    | Type_ref of
+        { type_ : string;
+          result :
+            [ `Found of string option * Lexing.position
+            | `Builtin of string
+            | `Not_in_env of string
+            | `File_not_found of string
+            | `Not_found of string * string option ]
+        }
+  [@@deriving yojson]
+
+  type type_tree = { data : node_data; children : type_tree list }
+  [@@deriving yojson]
+
+  type t = Success of type_tree | Invalid_context [@@deriving yojson]
+end

--- a/src/frontend/kernel/query_protocol_kernel.ml
+++ b/src/frontend/kernel/query_protocol_kernel.ml
@@ -2,38 +2,6 @@
    is useful because it allows VSCode extensions (which run in javascript) to use the
    serializers/deserializers defined in this module. *)
 
-open struct
-  include Ppx_yojson_conv_lib.Yojson_conv.Primitives
-
-  module Lexing = struct
-    include Lexing
-
-    type nonrec position = position =
-      { pos_fname : string; pos_lnum : int; pos_bol : int; pos_cnum : int }
-    [@@deriving yojson]
-  end
-end
-
-module Locate_type_multi_result = struct
-  open Ppx_yojson_conv_lib.Yojson_conv.Primitives
-
-  type node_data =
-    | Arrow
-    | Tuple
-    | Object
-    | Type_ref of
-        { type_ : string;
-          result :
-            [ `Found of string option * Lexing.position
-            | `Builtin of string
-            | `Not_in_env of string
-            | `File_not_found of string
-            | `Not_found of string * string option ]
-        }
-  [@@deriving yojson]
-
-  type type_tree = { data : node_data; children : type_tree list }
-  [@@deriving yojson]
-
-  type t = Success of type_tree | Invalid_context [@@deriving yojson]
-end
+module Completion_kind = Completion_kind
+module Locate_context = Locate_context
+module Locate_type_multi_result = Locate_type_multi_result

--- a/src/frontend/query_commands.ml
+++ b/src/frontend/query_commands.ml
@@ -474,6 +474,74 @@ let dispatch pipeline (type a) : a Query_protocol.t -> a = function
         | `Found { file; location; _ } -> `Found (Some file, location.loc_start)
         | `File_not_found _ as s -> s)
     end
+  | Locate_type_multi pos -> (
+    let typer = Mpipeline.typer_result pipeline in
+    let verbosity = verbosity pipeline in
+    let local_defs = Mtyper.get_typedtree typer in
+    let structures = Mbrowse.of_typedtree local_defs in
+    let pos = Mpipeline.get_lexing_pos pipeline pos in
+    let result =
+      let open Misc_stdlib.Monad.Option.Syntax in
+      let* env, node =
+        match Mbrowse.enclosing pos [ structures ] with
+        | path :: _ -> Some path
+        | [] -> None
+      in
+      let* overall_ty =
+        Locate.log ~title:"query_commands Locate_type_multi"
+          "inspecting node: %s"
+          (Browse_raw.string_of_node node);
+        match node with
+        | Expression { exp_type = ty; _ }
+        | Pattern { pat_type = ty; _ }
+        | Core_type { ctyp_type = ty; _ }
+        | Value_description { val_desc = { ctyp_type = ty; _ }; _ } -> Some ty
+        | _ -> None
+      in
+      let+ type_tree = Locate_type_multi.create_type_tree overall_ty in
+      let type_to_string ~env ty =
+        Printtyp.wrap_printing_env env ~verbosity (fun () ->
+            Type_utils.print_type_with_decl ~verbosity env Format.str_formatter
+              ty);
+        Format.flush_str_formatter ()
+      in
+      let rec make_result ({ data; children } : Locate_type_multi.Type_tree.t) :
+          Locate_type_multi_result.type_tree =
+        let data : Locate_type_multi_result.node_data =
+          match data with
+          | Arrow -> Arrow
+          | Tuple -> Tuple
+          | Object -> Object
+          | Type_ref { path; ty } ->
+            Locate.log ~title:"debug" "found type: %s" (Path.name path);
+            let config : Locate.config =
+              { mconfig = Mpipeline.final_config pipeline;
+                ml_or_mli = `MLI;
+                traverse_aliases = true
+              }
+            in
+            let result =
+              match
+                Locate.from_path ~config ~env ~local_defs ~namespace:Type path
+              with
+              | `Builtin (_, s) -> `Builtin s
+              | `Not_in_env _ as s -> s
+              | `Not_found _ as s -> s
+              | `Found { file; location; _ } ->
+                `Found (Some file, location.loc_start)
+              | `File_not_found _ as s -> s
+            in
+            let type_ = type_to_string ~env ty in
+            Type_ref { type_; result }
+        in
+        let children = List.map children ~f:make_result in
+        { data; children }
+      in
+      make_result type_tree
+    in
+    match result with
+    | Some result -> Success result
+    | None -> Invalid_context)
   | Complete_prefix (prefix, pos, kinds, with_doc, with_types) ->
     let pipeline, typer = for_completion pipeline pos in
     let config = Mpipeline.final_config pipeline in

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -56,15 +56,8 @@ module Compl = struct
       context : [ `Unknown | `Application of application_context ]
     }
 
-  type kind =
-    [ `Constructor
-    | `Labels
-    | `Modules
-    | `Modules_type
-    | `Types
-    | `Values
-    | `Variants
-    | `Keywords ]
+  module Kind = Completion_kind
+  type kind = Kind.t
 end
 
 type completions = Compl.t
@@ -131,53 +124,7 @@ type _ _bool = bool
 type occurrences_status =
   [ `Not_requested | `Out_of_sync of string list | `No_def | `Included ]
 
-module Locate_context = struct
-  type t =
-    | Expr
-    | Module_path
-    | Module_type
-    | Patt
-    | Type
-    | Constant
-    | Constructor
-    | Label
-    | Unknown
-
-  let to_string = function
-    | Expr -> "expr"
-    | Module_path -> "module_path"
-    | Module_type -> "module_type"
-    | Patt -> "pattern"
-    | Type -> "type"
-    | Constant -> "constant"
-    | Constructor -> "constructor"
-    | Label -> "label"
-    | Unknown -> "unknown"
-
-  let of_string = function
-    | "expr" -> Some Expr
-    | "module_path" -> Some Module_path
-    | "module_type" -> Some Module_type
-    | "pattern" -> Some Patt
-    | "type" -> Some Type
-    | "constant" -> Some Constant
-    | "constructor" -> Some Constructor
-    | "label" -> Some Label
-    | "unknown" -> Some Unknown
-    | _ -> None
-
-  let all =
-    [ Expr;
-      Module_path;
-      Module_type;
-      Patt;
-      Type;
-      Constant;
-      Constructor;
-      Label;
-      Unknown
-    ]
-end
+module Locate_context = Locate_context
 
 type _ t =
   | Type_expr (* *) : string * Msource.position -> string t

--- a/src/frontend/query_protocol.ml
+++ b/src/frontend/query_protocol.ml
@@ -26,6 +26,8 @@
 
    )* }}} *)
 
+include Query_protocol_kernel
+
 module Compl = struct
   type 'desc raw_entry =
     { name : string;
@@ -229,6 +231,7 @@ type _ t =
          | `Not_found of string * string option
          | `At_origin ]
          t
+  | Locate_type_multi : Msource.position -> Locate_type_multi_result.t t
   | Locate (* *) :
       string option
       * [ `ML | `MLI ]

--- a/src/utils/dune
+++ b/src/utils/dune
@@ -3,5 +3,5 @@
 (library
  (name merlin_utils)
  (public_name merlin-lib.utils)
- (libraries str unix)
+ (libraries str unix yojson)
  (foreign_stubs (language c) (names platform_misc)))

--- a/src/utils/std.ml
+++ b/src/utils/std.ml
@@ -54,6 +54,8 @@ module Json = struct
       "Logger error: `Std.Json.pretty_to_string` is not set. You should \
        initialize that reference with the pretifier of your choice to enable \
        json logging. A common one is `Yojson.Basic.pretty_to_string`."
+
+  let of_yojson_safe = Yojson.Safe.to_basic
 end
 
 module Hashtbl = struct

--- a/tests/test-dirs/locate-type-multi.t
+++ b/tests/test-dirs/locate-type-multi.t
@@ -1,0 +1,190 @@
+Test the locate-type-multi command
+
+Create a function that runs locate-type-multi on a variable of a given type
+  $ run () {
+  >   type="$1"
+  > 
+  >   # Create a file that creates a variable of the given type. We also define some
+  >   # types for us to be able to reference.
+  >   cat > foo.ml <<EOF
+  > type a
+  > type b
+  > type c
+  > type 'a one_arg
+  > type ('a, 'b) two_arg
+  > type aliased = t
+  > let () =
+  >   (* This double Obj.magic is to avoid a kind error *)
+  >   let foo : $type = (Obj.magic (Obj.magic 0)) 0 in
+  >   ()
+  > EOF
+  > 
+  >   $MERLIN single locate-type-multi -position "9:7" -filename foo.ml < foo.ml \
+  >     | jq .value[1] \
+  >     | jq -r '
+  >         def format_node:
+  >           if .data[0] == "Type_ref" then
+  >             # Check if result is null or position info is missing
+  >             if .data[1].result == null or .data[1].result[2] == null then
+  >               # No position info available
+  >               .data[1].type_
+  >             else
+  >               # Extract type_, line number, and calculate column
+  >               .data[1].type_ + " (" + 
+  >               (.data[1].result[2].pos_lnum | tostring) + ":" + 
+  >               ((.data[1].result[2].pos_cnum - .data[1].result[2].pos_bol) | tostring) + 
+  >               ")"
+  >             end
+  >           else
+  >             .data[0]
+  >           end;
+  >         
+  >         def process_tree($indent):
+  >           format_node as $node_text |
+  >           $indent + $node_text + 
+  >           if .children | length > 0 then
+  >             "\n" + (.children | map(process_tree($indent + "  ")) | join("\n"))
+  >           else
+  >             ""
+  >           end;
+  >         
+  >         process_tree("")
+  >         '
+  > }
+
+  $ run2 () {
+  >   type="$1"
+  > 
+  >   # Create a file that creates a variable of the given type. We also define some
+  >   # types for us to be able to reference.
+  >   cat > foo.ml <<EOF
+  > type a
+  > type b
+  > type c
+  > type 'a one_arg
+  > type ('a, 'b) two_arg
+  > type aliased = t
+  > let () =
+  >   (* This double Obj.magic is to avoid a kind error *)
+  >   let foo : $type = (Obj.magic (Obj.magic 0)) 0 in
+  >   ()
+  > EOF
+  > 
+  >   $MERLIN single locate-type-multi -position "9:7" -filename foo.ml < foo.ml \
+  >     | jq .value
+  > }
+
+Basic type constructors
+
+  $ run "a"
+  a (1:5)
+
+  $ run "a one_arg"
+  one_arg (4:8)
+    a (1:5)
+
+  $ run "(a, b) two_arg"
+  two_arg (5:14)
+    a (1:5)
+    b (2:5)
+  $ run "(b, a) two_arg"
+  two_arg (5:14)
+    b (2:5)
+    a (1:5)
+
+Functions
+
+  $ run "a -> b -> c"
+  Arrow
+    a (1:5)
+    b (2:5)
+    c (3:5)
+
+  $ run "x:a -> ?y:b -> c"
+  Arrow
+    a (1:5)
+    option
+      b (2:5)
+    c (3:5)
+
+Tuples
+
+  $ run "a * b * c"
+  Tuple
+    a (1:5)
+    b (2:5)
+    c (3:5)
+
+  $ run "x:a * b"
+  Tuple
+    a (1:5)
+    b (2:5)
+
+  $ run "#(a * b * c)"
+  Tuple
+    a (1:5)
+    b (2:5)
+    c (3:5)
+
+  $ run "#(x:a * b)"
+  Tuple
+    a (1:5)
+    b (2:5)
+
+Type variables
+
+  $ run "_ one_arg"
+  one_arg (4:8)
+
+  $ run "'a one_arg"
+  one_arg (4:8)
+
+Objects
+
+  $ run "<x : a; y : b>"
+  Object
+    a (1:5)
+    b (2:5)
+
+Primitive types
+
+  $ run "string"
+  string
+
+  $ run "int"
+  int
+
+  $ run "a option"
+  option
+    a (1:5)
+
+  $ run "a list"
+  list
+    a (1:5)
+
+Compound types
+
+  $ run "(a * b) one_arg"
+  one_arg (4:8)
+    Tuple
+      a (1:5)
+      b (2:5)
+
+  $ run "(a option, _) two_arg"
+  two_arg (5:14)
+    option
+      a (1:5)
+
+  $ run "a -> b -> #(x:a * b)"
+  Arrow
+    a (1:5)
+    b (2:5)
+    Tuple
+      a (1:5)
+      b (2:5)
+
+  $ run "((a one_arg) list) option"
+  option
+    list
+      one_arg (4:8)
+        a (1:5)


### PR DESCRIPTION
We want to use these types in a vscode extension, so this pr moves them to a jsoo-compatible library. I'm also using this feature as a trojan horse for two minor changes:
1. Use `ppx_string_conv` and `ppx_enumerate` for `Locate_context`.
2. For some reason, Merlin's serialization of `` `Keywords `` (of the type `Compl.kind`) doesn't round trip. This PR makes it round trip by adding `keywords` as a valid input string.