### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/test-dirs/dune
+++ b/tests/test-dirs/dune
@@ -5,6 +5,10 @@
   (<> %{os_type} Win32)))
 
 (cram
+ (applies_to parameters)
+ (locks server-tests/merlin_server))
+
+(cram
  (applies_to typing-recovery)
  (enabled_if
   (and


### PR DESCRIPTION
The tests for parameterized libs (`tests/test-dirs/parameters.t`) have been flaky. Presumably this is because they use the merlin server, and multiple tests that use the Merlin server running concurrently can cause unexpected behavior. There is prior art to dealing with this - [dune locks](https://dune.readthedocs.io/en/stable/concepts/locks.html), as seen in `tests/test-dirs/server-tests/dune`. This PR makes the `parameters.t` test take out the `merlin_server` lock.

Locally on my computer, I have been able to reliably trigger a test failure when building and running tests from a clean repo. After this change, I have not triggered the error (n=4), so I am fairly confident that this change fixes the issue.