### PR TITLE
merlin overrides use interval tree instead of list

### DIFF
--- a/src/analysis/overrides.ml
+++ b/src/analysis/overrides.ml
@@ -89,14 +89,14 @@ module Override = struct
       Ok { loc = { Location.loc_start; loc_end; loc_ghost }; payload }
     | _ -> error_unexpected_merlin_override_attribute_structure
 
-  let is_target_override t ~cursor =
-    Lexing.compare_pos cursor t.loc.loc_start >= 0
-    && Lexing.compare_pos cursor t.loc.loc_end <= 0
-
   let payload t = t.payload
+
+  let to_interval t =
+    Overrides_interval_tree.Interval.create ~low:t.loc.loc_start.pos_cnum
+      ~high:t.loc.loc_end.pos_cnum ~payload:t
 end
 
-type t = Override.t list
+type t = Override.t Overrides_interval_tree.t
 
 let rec of_payload ~attribute_name ({ pexp_desc; _ } : Parsetree.expression) =
   match pexp_desc with
@@ -137,17 +137,20 @@ let get_overrides ~attribute_name pipeline =
             Some attr
           | _ -> None)
   in
-  List.concat_map attributes ~f:(fun attribute ->
-      match of_attribute ~attribute_name attribute with
-      | Ok overrides -> overrides
-      | Error err ->
-        log ~title:"get_overrides" "%s" err;
-        [])
+  attributes
+  |> List.concat_map ~f:(fun attribute ->
+         match of_attribute ~attribute_name attribute with
+         | Ok overrides -> overrides
+         | Error err ->
+           log ~title:"get_overrides" "%s" err;
+           [])
+  |> List.filter_map ~f:(fun (override : Override.t) ->
+         match Override.to_interval override with
+         | Ok interval -> Some interval
+         | Error err ->
+           log ~title:"get_overrides" "%s" err;
+           None)
+  |> Overrides_interval_tree.of_alist
 
-let find t ~cursor =
-  match List.find_all ~f:(Override.is_target_override ~cursor) t with
-  | [] -> None
-  | override :: [] -> Some override
-  | override :: _ :: _ ->
-    log ~title:"find" "found multiple target overrides, using first target";
-    Some override
+let find (t : t) ~(cursor : Lexing.position) =
+  Overrides_interval_tree.find t cursor.pos_cnum

--- a/src/analysis/overrides.ml
+++ b/src/analysis/overrides.ml
@@ -92,8 +92,7 @@ module Override = struct
   let payload t = t.payload
 
   let to_interval t =
-    Overrides_interval_tree.Interval.create ~low:t.loc.loc_start.pos_cnum
-      ~high:t.loc.loc_end.pos_cnum ~payload:t
+    Overrides_interval_tree.Interval.create ~loc:t.loc ~payload:t
 end
 
 type t = Override.t Overrides_interval_tree.t
@@ -152,5 +151,4 @@ let get_overrides ~attribute_name pipeline =
            None)
   |> Overrides_interval_tree.of_alist
 
-let find (t : t) ~(cursor : Lexing.position) =
-  Overrides_interval_tree.find t cursor.pos_cnum
+let find t ~cursor = Overrides_interval_tree.find t cursor

--- a/src/analysis/overrides_interval_tree.ml
+++ b/src/analysis/overrides_interval_tree.ml
@@ -29,6 +29,7 @@ type 'a t =
     intervals : 'a Interval.t list
   }
 
+(** [empty] always returns [None] when [find] is called on it. *)
 let empty = { center = -1; left = None; right = None; intervals = [] }
 
 (** Implementation based off of

--- a/src/analysis/overrides_interval_tree.ml
+++ b/src/analysis/overrides_interval_tree.ml
@@ -1,85 +1,113 @@
-module Interval_tree = struct
-  module Interval = struct
-    type 'a t = { low : int; high : int; payload : 'a }
+module Interval = struct
+  type 'a t = { low : int; high : int; payload : 'a }
 
-    let create ~low ~high ~payload = { low; high; payload }
+  let create ~low ~high ~payload = { low; high; payload }
 
-    let compare t1 t2 = Int.compare t1.low t2.low
-  end
+  let compare_low t1 t2 = Int.compare t1.low t2.low
 
-  type 'a t =
-    { center : int;
-      left : 'a t option;
-      right : 'a t option;
-      intervals_by_low : 'a Interval.t list;
-      intervals_by_high : 'a Interval.t list
-    }
+  let compare_range t1 t2 = Int.compare (t1.high - t1.low) (t2.high - t2.low)
 
-  let rec construct (lst : _ Interval.t list) =
-    match List.length lst with
-    | 0 -> None
-    | length ->
-      let median =
-        let median_interval = List.nth lst (length / 2) in
-        (median_interval.low + median_interval.high) / 2
-      in
-      let to_left, to_overlap, to_right =
-        List.fold_right
-          (fun (interval : _ Interval.t) (to_left, to_overlap, to_right) ->
-            match (interval.low <= median, interval.high < median) with
-            | true, true -> (interval :: to_left, to_overlap, to_right)
-            | true, false -> (to_left, interval :: to_overlap, to_right)
-            | false, false -> (to_left, to_overlap, interval :: to_right)
-            | _ -> (to_left, to_overlap, to_right))
-          lst ([], [], [])
-      in
-      let left = construct to_left in
-      let right = construct to_right in
-      let intervals_by_low = to_overlap in
-      let intervals_by_high = List.rev to_overlap in
-      Some { center = median; left; right; intervals_by_low; intervals_by_high }
-
-  let of_alist lst =
-    let intervals =
-      lst
-      |> List.map (fun ((low, high), payload) ->
-             Interval.create ~low ~high ~payload)
-      |> List.stable_sort Interval.compare
-    in
-    match construct intervals with
-    | Some tree -> Ok tree
-    | None -> Error "input list has length 0"
-
-  let rec find_helper t point =
-    match point <= t.center with
-    | true -> (
-      let of_t =
-        List.filter
-          (fun (interval : _ Interval.t) -> interval.low <= point)
-          t.intervals_by_low
-      in
-      match t.left with
-      | Some left ->
-        let of_left = find_helper left point in
-        of_left @ of_t
-      | None -> of_t)
-    | false -> (
-      let of_t =
-        List.filter
-          (fun (interval : _ Interval.t) -> interval.high >= point)
-          t.intervals_by_high
-      in
-      match t.right with
-      | Some right ->
-        let of_right = find_helper right point in
-        of_right @ of_t
-      | None -> of_t)
-
-  let find (t : _ t) point =
-    find_helper t point
-    |> List.sort (fun (interval1 : _ Interval.t) interval2 ->
-           Int.compare
-             (interval1.high - interval1.low)
-             (interval2.high - interval2.low))
-    |> List.map (fun (interval : _ Interval.t) -> interval.payload)
+  let payload t = t.payload
 end
+
+type 'a t =
+  { center : int;
+    left : 'a t option;
+    right : 'a t option;
+    intervals : 'a Interval.t list
+  }
+
+let rec find_helper t point =
+  match point <= t.center with
+  | true -> (
+    let of_t =
+      List.filter
+        (fun (interval : _ Interval.t) -> interval.low <= point)
+        t.intervals
+    in
+    match t.left with
+    | Some left ->
+      let of_left = find_helper left point in
+      of_left @ of_t
+    | None -> of_t)
+  | false -> (
+    let of_t =
+      List.filter
+        (fun (interval : _ Interval.t) -> interval.high > point)
+        t.intervals
+    in
+    match t.right with
+    | Some right ->
+      let of_right = find_helper right point in
+      of_right @ of_t
+    | None -> of_t)
+
+let find t point =
+  let intervals =
+    find_helper t point
+    |> List.sort Interval.compare_range
+    |> List.map Interval.payload
+  in
+  match intervals with
+  | [] -> None
+  | first :: _ -> Some first
+
+let rec of_alist_helper (lst : _ Interval.t array) =
+  match Array.length lst with
+  | 0 -> None
+  | length ->
+    (* The middle of the range of the middle interval is a close approximation to the
+       median. *)
+    let median =
+      let median_interval = Array.get lst (length / 2) in
+      (median_interval.low + median_interval.high) / 2
+    in
+    let target = Array.copy lst in
+    let left_count, overlap_count =
+      Array.fold_left
+        (fun (left_count, overlap_count) (interval : _ Interval.t) ->
+          match (interval.low <= median, interval.high < median) with
+          | true, true -> (left_count + 1, overlap_count)
+          | true, false -> (left_count, overlap_count + 1)
+          | false, false -> (left_count, overlap_count)
+          | _ ->
+            raise
+              (Invalid_argument
+                 "input interval ranges do not follow a total ordering"))
+        (0, 0) lst
+    in
+    let right_count = length - left_count - overlap_count in
+    let left_i, overlap_i, right_i =
+      (ref 0, ref left_count, ref (left_count + overlap_count))
+    in
+    Array.iter
+      (fun (interval : _ Interval.t) ->
+        match (interval.low <= median, interval.high < median) with
+        | true, true ->
+          Array.set target !left_i interval;
+          left_i := !left_i + 1
+        | true, false ->
+          Array.set target !overlap_i interval;
+          overlap_i := !overlap_i + 1
+        | false, false ->
+          Array.set target !right_i interval;
+          right_i := !right_i + 1
+        | _ ->
+          raise
+            (Invalid_argument
+               "input interval ranges do not follow a total ordering"))
+      lst;
+    let left = of_alist_helper (Array.sub target 0 left_count) in
+    let right =
+      of_alist_helper
+        (Array.sub target (left_count + overlap_count) right_count)
+    in
+    let intervals = Array.to_list (Array.sub target left_count overlap_count) in
+    Some { center = median; left; right; intervals }
+
+let of_alist_exn lst =
+  let intervals = Array.of_list lst in
+  Array.stable_sort Interval.compare_low intervals;
+  match of_alist_helper intervals with
+  | Some tree -> tree
+  | None -> raise (Invalid_argument "input list is empty")

--- a/src/analysis/overrides_interval_tree.ml
+++ b/src/analysis/overrides_interval_tree.ml
@@ -1,0 +1,85 @@
+module Interval_tree = struct
+  module Interval = struct
+    type 'a t = { low : int; high : int; payload : 'a }
+
+    let create ~low ~high ~payload = { low; high; payload }
+
+    let compare t1 t2 = Int.compare t1.low t2.low
+  end
+
+  type 'a t =
+    { center : int;
+      left : 'a t option;
+      right : 'a t option;
+      intervals_by_low : 'a Interval.t list;
+      intervals_by_high : 'a Interval.t list
+    }
+
+  let rec construct (lst : _ Interval.t list) =
+    match List.length lst with
+    | 0 -> None
+    | length ->
+      let median =
+        let median_interval = List.nth lst (length / 2) in
+        (median_interval.low + median_interval.high) / 2
+      in
+      let to_left, to_overlap, to_right =
+        List.fold_right
+          (fun (interval : _ Interval.t) (to_left, to_overlap, to_right) ->
+            match (interval.low <= median, interval.high < median) with
+            | true, true -> (interval :: to_left, to_overlap, to_right)
+            | true, false -> (to_left, interval :: to_overlap, to_right)
+            | false, false -> (to_left, to_overlap, interval :: to_right)
+            | _ -> (to_left, to_overlap, to_right))
+          lst ([], [], [])
+      in
+      let left = construct to_left in
+      let right = construct to_right in
+      let intervals_by_low = to_overlap in
+      let intervals_by_high = List.rev to_overlap in
+      Some { center = median; left; right; intervals_by_low; intervals_by_high }
+
+  let of_alist lst =
+    let intervals =
+      lst
+      |> List.map (fun ((low, high), payload) ->
+             Interval.create ~low ~high ~payload)
+      |> List.stable_sort Interval.compare
+    in
+    match construct intervals with
+    | Some tree -> Ok tree
+    | None -> Error "input list has length 0"
+
+  let rec find_helper t point =
+    match point <= t.center with
+    | true -> (
+      let of_t =
+        List.filter
+          (fun (interval : _ Interval.t) -> interval.low <= point)
+          t.intervals_by_low
+      in
+      match t.left with
+      | Some left ->
+        let of_left = find_helper left point in
+        of_left @ of_t
+      | None -> of_t)
+    | false -> (
+      let of_t =
+        List.filter
+          (fun (interval : _ Interval.t) -> interval.high >= point)
+          t.intervals_by_high
+      in
+      match t.right with
+      | Some right ->
+        let of_right = find_helper right point in
+        of_right @ of_t
+      | None -> of_t)
+
+  let find (t : _ t) point =
+    find_helper t point
+    |> List.sort (fun (interval1 : _ Interval.t) interval2 ->
+           Int.compare
+             (interval1.high - interval1.low)
+             (interval2.high - interval2.low))
+    |> List.map (fun (interval : _ Interval.t) -> interval.payload)
+end

--- a/src/analysis/overrides_interval_tree.ml
+++ b/src/analysis/overrides_interval_tree.ml
@@ -1,102 +1,95 @@
 module Interval = struct
-  type 'a t = { low : int; high : int; payload : 'a }
+  type 'a t = { loc : Location.t; payload : 'a }
 
-  let create ~low ~high ~payload =
-    match low <= high with
-    | true -> Ok { low; high; payload }
-    | false -> Error "input low greater than high"
+  let create ~(loc : Location.t) ~payload =
+    match loc.loc_start.pos_cnum <= loc.loc_end.pos_cnum with
+    | true -> Ok { loc; payload }
+    | false -> Error "input loc_start greater than loc_end"
 
-  let compare_low t1 t2 = Int.compare t1.low t2.low
+  let compare_loc t1 t2 = Location_aux.compare t1.loc t2.loc
 
-  let compare_range t1 t2 = Int.compare (t1.high - t1.low) (t2.high - t2.low)
+  let loc t = t.loc
+  let low t = t.loc.loc_start.pos_cnum
+  let high t = t.loc.loc_end.pos_cnum
+
+  let compare_range t1 t2 = Int.compare (high t1 - low t1) (high t2 - low t2)
 
   let payload t = t.payload
 end
 
-(** The type representing an interval tree node.
-
-    [center] is an approximation of the median of all intervals contained in the subtree [t].
-
-    [left] is the subtree containing all intervals to the left of [center].
-
-    [left] is the subtree containing all intervals to the right of [center].
-
-    [intervals] is a list of all intervals that contain [center] *)
+(** The type representing an interval tree node. *)
 type 'a t =
-  { center : int;
-    left : 'a t option;
-    right : 'a t option;
-    intervals : 'a Interval.t list
-  }
-
-(** [empty] always returns [None] when [find] is called on it. *)
-let empty = { center = -1; left = None; right = None; intervals = [] }
+  | Empty
+  | Node of
+      { center : Lexing.position;
+            (** [center] is an approximation of the median of all intervals contained in the subtree [t]. *)
+        left : 'a t;
+            (** [left] is the subtree containing all intervals to the left of [center]. *)
+        right : 'a t;
+            (** [left] is the subtree containing all intervals to the right of [center]. *)
+        intervals : 'a Interval.t list
+            (** [intervals] is a list of all intervals that contain [center] *)
+      }
 
 (** Implementation based off of
     {{:https://en.wikipedia.org/wiki/Interval_tree#With_a_point}}this description.  *)
-let rec find_helper t point =
-  match point <= t.center with
-  | true -> (
+let rec find_helper t position =
+  match t with
+  | Empty -> []
+  | Node node -> (
     let of_t =
       List.filter
-        (fun (interval : _ Interval.t) -> interval.low <= point)
-        t.intervals
+        (fun (interval : _ Interval.t) ->
+          Location_aux.compare_pos position (Interval.loc interval) = 0)
+        node.intervals
     in
-    match t.left with
-    | Some left ->
-      let of_left = find_helper left point in
+    match Std.Lexing.compare_pos position node.center with
+    | n when n < 0 ->
+      let of_left = find_helper node.left position in
       of_left @ of_t
-    | None -> of_t)
-  | false -> (
-    let of_t =
-      List.filter
-        (fun (interval : _ Interval.t) -> interval.high > point)
-        t.intervals
-    in
-    match t.right with
-    | Some right ->
-      let of_right = find_helper right point in
+    | n when n > 0 ->
+      let of_right = find_helper node.right position in
       of_right @ of_t
-    | None -> of_t)
+    | _ -> of_t)
 
 let find t point =
-  let intervals =
-    find_helper t point
-    |> List.sort Interval.compare_range
-    |> List.map Interval.payload
+  let tightest_interval =
+    find_helper t point |> Std.List.min_elt ~cmp:Interval.compare_range
   in
-  match intervals with
-  | [] -> None
-  | first :: _ -> Some first
+  match tightest_interval with
+  | None -> None
+  | Some interval -> Some (Interval.payload interval)
 
 let rec of_alist_helper (lst : _ Interval.t list) =
   match List.length lst with
-  | 0 -> None
+  | 0 -> Empty
   | length ->
     let median =
-      (* The middle of the range of the middle interval is a close approximation to the
-         median. *)
+      (* The start position of the range of the middle interval is a close approximation
+         to the median. *)
       let median_interval = List.nth lst (length / 2) in
-      (median_interval.low + median_interval.high) / 2
+      (Interval.loc median_interval).loc_start
     in
     let to_left, to_overlap, to_right =
       List.fold_right
         (fun (interval : _ Interval.t) (to_left, to_overlap, to_right) ->
-          match (interval.low <= median, interval.high < median) with
-          | true, true -> (interval :: to_left, to_overlap, to_right)
-          | true, false -> (to_left, interval :: to_overlap, to_right)
-          | false, false -> (to_left, to_overlap, interval :: to_right)
-          | _ ->
-            raise (Invalid_argument "input interval has low greater than high"))
+          match Location_aux.compare_pos median (Interval.loc interval) with
+          | n when n > 0 -> (interval :: to_left, to_overlap, to_right)
+          | n when n < 0 -> (to_left, to_overlap, interval :: to_right)
+          | _ -> (to_left, interval :: to_overlap, to_right))
         lst ([], [], [])
     in
     let left = of_alist_helper to_left in
     let right = of_alist_helper to_right in
     let intervals = to_overlap in
-    Some { center = median; left; right; intervals }
+    Node { center = median; left; right; intervals }
 
 let of_alist lst =
-  let sorted_lst = List.stable_sort Interval.compare_low lst in
-  match of_alist_helper sorted_lst with
-  | Some tree -> tree
-  | None -> empty
+  lst
+  (* Sorting using [Interval.compare_loc] does not guarantee a well-balanced interval tree
+     construction on all possible inputs because [Interval.compare_loc] compares
+     [loc_start] first, then compares [loc_end]. However, because this is used only by
+     [Overrides.t] which typically handles disjoint and sparse [Location.t] ranges, this
+     sorting should be a good heuristic. *)
+  |> List.stable_sort Interval.compare_loc
+  |> of_alist_helper

--- a/src/analysis/overrides_interval_tree.ml
+++ b/src/analysis/overrides_interval_tree.ml
@@ -1,10 +1,14 @@
-let input_has_no_total_ordering =
-  Invalid_argument "input interval ranges do not follow a total ordering"
+let input_low_greater_than_high = Invalid_argument "input low greater than high"
+
+let input_invalid_interval_range =
+  Invalid_argument "input interval ranges has low greater than high"
 
 module Interval = struct
   type 'a t = { low : int; high : int; payload : 'a }
 
-  let create ~low ~high ~payload = { low; high; payload }
+  let create ~low ~high ~payload =
+    if low > high then raise input_low_greater_than_high
+    else { low; high; payload }
 
   let compare_low t1 t2 = Int.compare t1.low t2.low
 
@@ -75,7 +79,7 @@ let rec of_alist_helper (lst : _ Interval.t array) =
           | true, true -> (left_count + 1, overlap_count)
           | true, false -> (left_count, overlap_count + 1)
           | false, false -> (left_count, overlap_count)
-          | _ -> raise input_has_no_total_ordering)
+          | _ -> raise input_invalid_interval_range)
         (0, 0) lst
     in
     let right_count = length - left_count - overlap_count in
@@ -94,7 +98,7 @@ let rec of_alist_helper (lst : _ Interval.t array) =
         | false, false ->
           Array.set target !right_i interval;
           right_i := !right_i + 1
-        | _ -> raise input_has_no_total_ordering)
+        | _ -> raise input_invalid_interval_range)
       lst;
     let left = of_alist_helper (Array.sub target 0 left_count) in
     let right =

--- a/src/analysis/overrides_interval_tree.ml
+++ b/src/analysis/overrides_interval_tree.ml
@@ -1,3 +1,6 @@
+let input_has_no_total_ordering =
+  Invalid_argument "input interval ranges do not follow a total ordering"
+
 module Interval = struct
   type 'a t = { low : int; high : int; payload : 'a }
 
@@ -62,6 +65,8 @@ let rec of_alist_helper (lst : _ Interval.t array) =
       let median_interval = Array.get lst (length / 2) in
       (median_interval.low + median_interval.high) / 2
     in
+    (* A two-pass, out-of-place, stable partition. A stable partition is desired such that
+       medians can be easily calculated in recursive calls *)
     let target = Array.copy lst in
     let left_count, overlap_count =
       Array.fold_left
@@ -70,10 +75,7 @@ let rec of_alist_helper (lst : _ Interval.t array) =
           | true, true -> (left_count + 1, overlap_count)
           | true, false -> (left_count, overlap_count + 1)
           | false, false -> (left_count, overlap_count)
-          | _ ->
-            raise
-              (Invalid_argument
-                 "input interval ranges do not follow a total ordering"))
+          | _ -> raise input_has_no_total_ordering)
         (0, 0) lst
     in
     let right_count = length - left_count - overlap_count in
@@ -92,10 +94,7 @@ let rec of_alist_helper (lst : _ Interval.t array) =
         | false, false ->
           Array.set target !right_i interval;
           right_i := !right_i + 1
-        | _ ->
-          raise
-            (Invalid_argument
-               "input interval ranges do not follow a total ordering"))
+        | _ -> raise input_has_no_total_ordering)
       lst;
     let left = of_alist_helper (Array.sub target 0 left_count) in
     let right =

--- a/src/analysis/overrides_interval_tree.ml
+++ b/src/analysis/overrides_interval_tree.ml
@@ -1,9 +1,10 @@
 module Interval = struct
   type 'a t = { low : int; high : int; payload : 'a }
 
-  let create_exn ~low ~high ~payload =
-    if low > high then raise (Invalid_argument "input low greater than high")
-    else { low; high; payload }
+  let create ~low ~high ~payload =
+    match low <= high with
+    | true -> Ok { low; high; payload }
+    | false -> Error "input low greater than high"
 
   let compare_low t1 t2 = Int.compare t1.low t2.low
 
@@ -27,6 +28,8 @@ type 'a t =
     right : 'a t option;
     intervals : 'a Interval.t list
   }
+
+let empty = { center = -1; left = None; right = None; intervals = [] }
 
 (** Implementation based off of
     {{:https://en.wikipedia.org/wiki/Interval_tree#With_a_point}}this description.  *)
@@ -91,8 +94,8 @@ let rec of_alist_helper (lst : _ Interval.t list) =
     let intervals = to_overlap in
     Some { center = median; left; right; intervals }
 
-let of_alist_exn lst =
+let of_alist lst =
   let sorted_lst = List.stable_sort Interval.compare_low lst in
   match of_alist_helper sorted_lst with
   | Some tree -> tree
-  | None -> raise (Invalid_argument "input list is empty")
+  | None -> empty

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -12,21 +12,24 @@
     The general design of the data structure is on
     {{:https://en.wikipedia.org/wiki/Interval_tree#Centered_interval_tree}this wiki page}. *)
 
+(** [Interval] contains an interval tree entry's range and payload. *)
 module Interval : sig
   type 'a t
 
   (** [low] is included in the range. [high] is excluded from the range. Raises if input
       [low] > [high]. *)
-  val create : low:int -> high:int -> payload:'a -> 'a t
+  val create_exn : low:int -> high:int -> payload:'a -> 'a t
 end
 
 type 'a t
 
-(** Find the tightest interval that contains a given integer point.
+(** Find the tightest interval that contains a given integer point. Runs in O(logn + mlogm)
+    where m is the number of intervals containing the point.
 
     [find] assumes a total ordering. Ties imply equivalence, and we return the
-    first. Without total ordering, the interval with the lowest [low] is chosen. *)
+    first. *)
 val find : 'a t -> int -> 'a option
 
-(** Constructs a ['a t] given a list of ['a Interval.t]. Raises on empty lists. *)
+(** Constructs a ['a t] given a list of ['a Interval.t]. Runs in O(nlogn) time. Raises on
+    empty lists. *)
 val of_alist_exn : 'a Interval.t list -> 'a t

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -2,9 +2,6 @@
     intervals to values ['a] and allows efficient queries for intervals that contain a
     given point.
 
-    Interval tree assumes that input intervals have a total ordering, such as AST node
-    locations.
-
     This is the minimal interface to support querying [[@@@merlin]] overrides by cursor
     position. Common functions, such as [insert] and [delete], are left unimplemented since
     they are not necessary, but are possibly easy to include.
@@ -18,7 +15,7 @@ module Interval : sig
 
   (** [low] is included in the range. [high] is excluded from the range. Returns [Error] if
       [low] > [high] *)
-  val create : low:int -> high:int -> payload:'a -> ('a t, string) result
+  val create : loc:Location.t -> payload:'a -> ('a t, string) result
 end
 
 type 'a t
@@ -26,9 +23,10 @@ type 'a t
 (** Find the tightest interval that contains a given integer point. Runs in O(logn + mlogm)
     where m is the number of intervals containing the point.
 
-    [find] assumes a total ordering. Ties imply equivalence, and we return the
-    first. *)
-val find : 'a t -> int -> 'a option
+    [find] assumes that an interval is either contained by or contains every other interval.
+    If there are multiple matching intervals of the same tightness, the interval that came
+    first in the list during construction is returned. *)
+val find : 'a t -> Lexing.position -> 'a option
 
 (** Constructs a ['a t] given a list of ['a Interval.t]. Runs in O(nlogn) time. *)
 val of_alist : 'a Interval.t list -> 'a t

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -13,8 +13,7 @@
 module Interval : sig
   type 'a t
 
-  (** [low] is included in the range. [high] is excluded from the range. Returns [Error] if
-      [low] > [high] *)
+  (** [low] and [high] are included in the range. Returns [Error] if [low] > [high] *)
   val create : loc:Location.t -> payload:'a -> ('a t, string) result
 end
 

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -19,7 +19,7 @@ end
 
 type 'a t
 
-(** Find the tightest interval that contains a given integer point. Runs in O(logn + mlogm)
+(** Find the tightest interval that contains a given integer point. Runs in O(logn + m)
     where m is the number of intervals containing the point.
 
     [find] assumes that an interval is either contained by or contains every other interval.

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -5,13 +5,17 @@
     This is the minimal interface to support querying [[@@@merlin]] overrides by cursor
     position. Common functions, such as [insert], are left unimplemented since
     they are not necessary, but are possibly easy to include. *)
-module Inteval_tree : sig
+module Interval_tree : sig
+  module Interval : sig
+    type 'a t = { low : int; high : int; payload : 'a }
+  end
+
   type 'a t
 
   (** Find the first interval that contains a given integer point. Runs with logarithmic
       asymptotic time complexity.  *)
-  val find : 'a t -> int -> 'a
+  val find : 'a t -> int -> 'a list
 
   (** Constructs a [t] given a list of intervals and payloads. *)
-  val of_alist : ((int * int) * 'a) list -> 'a t
+  val of_alist : ((int * int) * 'a) list -> ('a t, string) result
 end

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -1,13 +1,16 @@
-(** This [Interval_tree] is an immutable data structure that stores mappings from integer
+(** This interval tree is an immutable data structure that stores mappings from integer
     intervals to values ['a] and allows efficient queries for intervals that contain a
     given point.
 
-    [Interval_tree] assumes that input intervals have a total ordering, such as AST node
+    Interval tree assumes that input intervals have a total ordering, such as AST node
     locations.
 
     This is the minimal interface to support querying [[@@@merlin]] overrides by cursor
     position. Common functions, such as [insert] and [delete], are left unimplemented since
-    they are not necessary, but are possibly easy to include. *)
+    they are not necessary, but are possibly easy to include.
+
+    The general design of the data structure is on
+    {{:https://en.wikipedia.org/wiki/Interval_tree#Centered_interval_tree}this wiki page}. *)
 
 module Interval : sig
   type 'a t
@@ -18,11 +21,10 @@ end
 
 type 'a t
 
-(** Find the tightest interval that contains a given integer point. Runs with logarithmic
-    asymptotic time complexity.
+(** Find the tightest interval that contains a given integer point.
 
-    [Interval_tree] assumes a total ordering. Ties imply equivalence, and we return the
-    first. *)
+    [find] assumes a total ordering. Ties imply equivalence, and we return the
+    first. Without total ordering, the interval with the lowest [low] is chosen. *)
 val find : 'a t -> int -> 'a option
 
 (** Constructs a ['a t] given a list of ['a Interval.t]. Raises on empty lists. *)

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -2,20 +2,28 @@
     intervals to values ['a] and allows efficient queries for intervals that contain a
     given point.
 
-    This is the minimal interface to support querying [[@@@merlin]] overrides by cursor
-    position. Common functions, such as [insert], are left unimplemented since
-    they are not necessary, but are possibly easy to include. *)
-module Interval_tree : sig
-  module Interval : sig
-    type 'a t = { low : int; high : int; payload : 'a }
-  end
+    [Interval_tree] assumes that input intervals have a total ordering, such as AST node
+    locations.
 
+    This is the minimal interface to support querying [[@@@merlin]] overrides by cursor
+    position. Common functions, such as [insert] and [delete], are left unimplemented since
+    they are not necessary, but are possibly easy to include. *)
+
+module Interval : sig
   type 'a t
 
-  (** Find the first interval that contains a given integer point. Runs with logarithmic
-      asymptotic time complexity.  *)
-  val find : 'a t -> int -> 'a list
-
-  (** Constructs a [t] given a list of intervals and payloads. *)
-  val of_alist : ((int * int) * 'a) list -> ('a t, string) result
+  (** [low] is included in the range. [high] is excluded from the range. *)
+  val create : low:int -> high:int -> payload:'a -> 'a t
 end
+
+type 'a t
+
+(** Find the tightest interval that contains a given integer point. Runs with logarithmic
+    asymptotic time complexity.
+
+    [Interval_tree] assumes a total ordering. Ties imply equivalence, and we return the
+    first. *)
+val find : 'a t -> int -> 'a option
+
+(** Constructs a ['a t] given a list of ['a Interval.t]. Raises on empty lists. *)
+val of_alist_exn : 'a Interval.t list -> 'a t

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -19,7 +19,7 @@ end
 
 type 'a t
 
-(** Find the tightest interval that contains a given integer point. Runs in O(logn + m)
+(** Find the tightest interval that contains a given position. Runs in O(logn + m)
     where m is the number of intervals containing the point.
 
     [find] assumes that an interval is either contained by or contains every other interval.

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -1,0 +1,17 @@
+(** This [Interval_tree] is an immutable data structure that stores mappings from integer
+    intervals to values ['a] and allows efficient queries for intervals that contain a
+    given point.
+
+    This is the minimal interface to support querying [[@@@merlin]] overrides by cursor
+    position. Common functions, such as [insert], are left unimplemented since
+    they are not necessary, but are possibly easy to include. *)
+module Inteval_tree : sig
+  type 'a t
+
+  (** Find the first interval that contains a given integer point. Runs with logarithmic
+      asymptotic time complexity.  *)
+  val find : 'a t -> int -> 'a
+
+  (** Constructs a [t] given a list of intervals and payloads. *)
+  val of_alist : ((int * int) * 'a) list -> 'a t
+end

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -16,9 +16,9 @@
 module Interval : sig
   type 'a t
 
-  (** [low] is included in the range. [high] is excluded from the range. Raises if input
-      [low] > [high]. *)
-  val create_exn : low:int -> high:int -> payload:'a -> 'a t
+  (** [low] is included in the range. [high] is excluded from the range. Returns [Error] if
+      [low] > [high] *)
+  val create : low:int -> high:int -> payload:'a -> ('a t, string) result
 end
 
 type 'a t
@@ -30,6 +30,5 @@ type 'a t
     first. *)
 val find : 'a t -> int -> 'a option
 
-(** Constructs a ['a t] given a list of ['a Interval.t]. Runs in O(nlogn) time. Raises on
-    empty lists. *)
-val of_alist_exn : 'a Interval.t list -> 'a t
+(** Constructs a ['a t] given a list of ['a Interval.t]. Runs in O(nlogn) time. *)
+val of_alist : 'a Interval.t list -> 'a t

--- a/src/analysis/overrides_interval_tree.mli
+++ b/src/analysis/overrides_interval_tree.mli
@@ -15,7 +15,8 @@
 module Interval : sig
   type 'a t
 
-  (** [low] is included in the range. [high] is excluded from the range. *)
+  (** [low] is included in the range. [high] is excluded from the range. Raises if input
+      [low] > [high]. *)
   val create : low:int -> high:int -> payload:'a -> 'a t
 end
 

--- a/tests/test-dirs/overrides.t
+++ b/tests/test-dirs/overrides.t
@@ -232,6 +232,24 @@ Test overrides on %swap
   }
   [merlin document] output: %swap swaps the first two arguments of a function call
 
+Test overrides on last character of %swap
+
+  $ test_merlin_overrides "2:14" "./basic.ml"
+  [merlin locate] output: {
+    "file": "$TESTCASE_ROOT/test/ppx.ml",
+    "pos": {
+      "line": 12,
+      "col": 24
+    }
+  }
+  [merlin document] output: %swap swaps the first two arguments of a function call
+
+Test overrides one character to the right of %swap
+
+  $ test_merlin_overrides "2:15" "./basic.ml"
+  [merlin locate] output: Not in environment 'f'
+  [merlin document] output: Not in environment 'f'
+
 Test overrides on @add_one
 
   $ test_merlin_overrides "3:13" "./basic.ml"

--- a/tests/test-dirs/overrides.t
+++ b/tests/test-dirs/overrides.t
@@ -373,9 +373,17 @@ Attribute location should not affect functionality.
   > [@@@merlin.document
   >   [ { location =
   >         { loc_start =
-  >             { pos_fname = "attribute-at-top.ml"; pos_lnum = 31; pos_bol = 867; pos_cnum = 880 }
+  >             { pos_fname = "attribute-at-top.ml"
+  >             ; pos_lnum = 42
+  >             ; pos_bol = 1014
+  >             ; pos_cnum = 1027
+  >             }
   >         ; loc_end =
-  >             { pos_fname = "attribute-at-top.ml"; pos_lnum = 31; pos_bol = 867; pos_cnum = 887 }
+  >             { pos_fname = "attribute-at-top.ml"
+  >             ; pos_lnum = 42
+  >             ; pos_bol = 1014
+  >             ; pos_cnum = 1034
+  >             }
   >         ; loc_ghost = false
   >         }
   >     ; payload = "@add_one expands expressions with a '+ 1'"
@@ -385,25 +393,28 @@ Attribute location should not affect functionality.
   > [@@@merlin.locate
   >   [ { location =
   >         { loc_start =
-  >             { pos_fname = "attribute-at-top.ml"; pos_lnum = 31; pos_bol = 867; pos_cnum = 880 }
+  >             { pos_fname = "attribute-at-top.ml"
+  >             ; pos_lnum = 42
+  >             ; pos_bol = 1014
+  >             ; pos_cnum = 1027
+  >             }
   >         ; loc_end =
-  >             { pos_fname = "attribute-at-top.ml"; pos_lnum = 31; pos_bol = 867; pos_cnum = 887 }
+  >             { pos_fname = "attribute-at-top.ml"
+  >             ; pos_lnum = 42
+  >             ; pos_bol = 1014
+  >             ; pos_cnum = 1034
+  >             }
   >         ; loc_ghost = false
   >         }
   >     ; payload =
-  >         { pos_fname =
-  >             "test/ppx.ml"
-  >         ; pos_lnum = 53
-  >         ; pos_bol = 1612
-  >         ; pos_cnum = 1633
-  >         }
+  >         { pos_fname = "test/ppx.ml"; pos_lnum = 53; pos_bol = 1612; pos_cnum = 1633 }
   >     }
   >   ]]
   > 
   > let _ = (0 [@add_one]) + 2
   > EOF
 
-  $ test_merlin_overrides "31:13" "./attribute-at-top.ml"
+  $ test_merlin_overrides "42:13" "./attribute-at-top.ml"
   [merlin locate] output: {
     "file": "$TESTCASE_ROOT/test/ppx.ml",
     "pos": {

--- a/tests/test-dirs/overrides.t
+++ b/tests/test-dirs/overrides.t
@@ -391,17 +391,9 @@ Attribute location should not affect functionality.
   > [@@@merlin.document
   >   [ { location =
   >         { loc_start =
-  >             { pos_fname = "attribute-at-top.ml"
-  >             ; pos_lnum = 42
-  >             ; pos_bol = 1014
-  >             ; pos_cnum = 1027
-  >             }
+  >             { pos_fname = "attribute-at-top.ml"; pos_lnum = 31; pos_bol = 867; pos_cnum = 880 }
   >         ; loc_end =
-  >             { pos_fname = "attribute-at-top.ml"
-  >             ; pos_lnum = 42
-  >             ; pos_bol = 1014
-  >             ; pos_cnum = 1034
-  >             }
+  >             { pos_fname = "attribute-at-top.ml"; pos_lnum = 31; pos_bol = 867; pos_cnum = 887 }
   >         ; loc_ghost = false
   >         }
   >     ; payload = "@add_one expands expressions with a '+ 1'"
@@ -411,28 +403,25 @@ Attribute location should not affect functionality.
   > [@@@merlin.locate
   >   [ { location =
   >         { loc_start =
-  >             { pos_fname = "attribute-at-top.ml"
-  >             ; pos_lnum = 42
-  >             ; pos_bol = 1014
-  >             ; pos_cnum = 1027
-  >             }
+  >             { pos_fname = "attribute-at-top.ml"; pos_lnum = 31; pos_bol = 867; pos_cnum = 880 }
   >         ; loc_end =
-  >             { pos_fname = "attribute-at-top.ml"
-  >             ; pos_lnum = 42
-  >             ; pos_bol = 1014
-  >             ; pos_cnum = 1034
-  >             }
+  >             { pos_fname = "attribute-at-top.ml"; pos_lnum = 31; pos_bol = 867; pos_cnum = 887 }
   >         ; loc_ghost = false
   >         }
   >     ; payload =
-  >         { pos_fname = "test/ppx.ml"; pos_lnum = 53; pos_bol = 1612; pos_cnum = 1633 }
+  >         { pos_fname =
+  >             "test/ppx.ml"
+  >         ; pos_lnum = 53
+  >         ; pos_bol = 1612
+  >         ; pos_cnum = 1633
+  >         }
   >     }
   >   ]]
   > 
   > let _ = (0 [@add_one]) + 2
   > EOF
 
-  $ test_merlin_overrides "42:13" "./attribute-at-top.ml"
+  $ test_merlin_overrides "31:13" "./attribute-at-top.ml"
   [merlin locate] output: {
     "file": "$TESTCASE_ROOT/test/ppx.ml",
     "pos": {

--- a/tests/test-units/analysis/analysis_test.ml
+++ b/tests/test-units/analysis/analysis_test.ml
@@ -1,0 +1,2 @@
+let () =
+  Alcotest.run "merlin-lib.analysis" [ Overrides_interval_tree_test.cases ]

--- a/tests/test-units/analysis/dune
+++ b/tests/test-units/analysis/dune
@@ -1,3 +1,4 @@
 (test
  (name analysis_test)
- (libraries alcotest merlin-lib.analysis))
+ (flags :standard -open Ocaml_parsing)
+ (libraries alcotest ocaml_parsing merlin-lib.analysis))

--- a/tests/test-units/analysis/dune
+++ b/tests/test-units/analysis/dune
@@ -1,0 +1,3 @@
+(test
+ (name analysis_test)
+ (libraries alcotest merlin-lib.analysis))

--- a/tests/test-units/analysis/overrides_interval_tree_test.ml
+++ b/tests/test-units/analysis/overrides_interval_tree_test.ml
@@ -25,14 +25,15 @@ let test_construct =
       in
       ())
 
-let test_construct_no_total_order =
+let test_construct_no_total_order_actual =
   let open Alcotest in
-  test_case "test construction of intervals without total ordering" `Quick
-    (fun () ->
+  test_case "test construction of intervals without total ordering actual"
+    `Quick (fun () ->
       check_raises "should raise exn"
-        (Invalid_argument "input interval es do not follow a total ordering")
-        (fun () ->
-          let _ = create_intervals [ ((0, 3), "1"); ((1, 4), "2") ] in
+        (Invalid_argument "input low greater than high") (fun () ->
+          let _ =
+            create_intervals [ ((0, 3), "1"); ((1, 4), "2"); ((5, 0), "3") ]
+          in
           ()))
 
 let test_find ~input ~expected =
@@ -77,7 +78,8 @@ let test_find_first =
 let cases =
   ( "overrides-interval-tree",
     [ test_construct;
-      test_construct_no_total_order;
+      (*= test_construct_no_total_order; *)
+      test_construct_no_total_order_actual;
       test_find ~input:0 ~expected:(Some "1");
       test_find ~input:1 ~expected:(Some "2");
       test_find ~input:2 ~expected:(Some "0");

--- a/tests/test-units/analysis/overrides_interval_tree_test.ml
+++ b/tests/test-units/analysis/overrides_interval_tree_test.ml
@@ -1,16 +1,16 @@
 open Merlin_analysis
 
-let create_intervals intervals =
+let create_tree intervals =
   intervals
   |> List.map (fun ((low, high), payload) ->
-         Overrides_interval_tree.Interval.create ~low ~high ~payload)
+         Overrides_interval_tree.Interval.create_exn ~low ~high ~payload)
   |> Overrides_interval_tree.of_alist_exn
 
-let test_construct =
+let test_of_alist_exn =
   let open Alcotest in
   test_case "test basic list construction" `Quick (fun () ->
       let _ : string Overrides_interval_tree.t =
-        create_intervals
+        create_tree
           [ ((0, 1), "1");
             ((0, 3), "2");
             ((2, 3), "3");
@@ -25,38 +25,46 @@ let test_construct =
       in
       ())
 
-let test_construct_no_total_order_actual =
+let test_empty_list =
   let open Alcotest in
-  test_case "test construction of intervals without total ordering actual"
-    `Quick (fun () ->
+  test_case "test basic list construction" `Quick (fun () ->
+      check_raises "should raise exn" (Invalid_argument "input list is empty")
+        (fun () ->
+          let _ : string Overrides_interval_tree.t = create_tree [] in
+          ()))
+
+let test_invalid_interval =
+  let open Alcotest in
+  test_case "test creating invalid interval" `Quick (fun () ->
       check_raises "should raise exn"
         (Invalid_argument "input low greater than high") (fun () ->
           let _ =
-            create_intervals [ ((0, 3), "1"); ((1, 4), "2"); ((5, 0), "3") ]
+            Overrides_interval_tree.Interval.create_exn ~low:5 ~high:0
+              ~payload:"invalid"
           in
           ()))
 
 let test_find ~input ~expected =
   (*
     0 1 2 3 4 5 6 7 8 9 10
-    ----------5---------
-    ----4---  -----6----
-    ---2--    --7-  --8-
-    -1  -3            -9
-        0
+    ----------e---------
+    ----d---  -----f----
+    ---b--    --g-  --h-
+    -a  -c            -i
+        j
    *)
   let tree =
-    create_intervals
-      [ ((0, 1), "1");
-        ((0, 3), "2");
-        ((2, 3), "3");
-        ((0, 4), "4");
-        ((0, 10), "5");
-        ((5, 10), "6");
-        ((5, 7), "7");
-        ((8, 10), "8");
-        ((9, 10), "9");
-        ((2, 2), "0")
+    create_tree
+      [ ((0, 1), "a");
+        ((0, 3), "b");
+        ((2, 3), "c");
+        ((0, 4), "d");
+        ((0, 10), "e");
+        ((5, 10), "f");
+        ((5, 7), "g");
+        ((8, 10), "h");
+        ((9, 10), "i");
+        ((2, 2), "j")
       ]
   in
   let open Alcotest in
@@ -68,7 +76,7 @@ let test_find ~input ~expected =
       check (option string) "should be equal" expected payload)
 
 let test_find_first =
-  let tree = create_intervals [ ((0, 4), "0"); ((2, 2), "1"); ((2, 2), "2") ] in
+  let tree = create_tree [ ((0, 4), "0"); ((2, 2), "1"); ((2, 2), "2") ] in
   let open Alcotest in
   test_case "test find on input with duplicate intervals" `Quick (fun () ->
       let expected = Some "1" in
@@ -77,19 +85,19 @@ let test_find_first =
 
 let cases =
   ( "overrides-interval-tree",
-    [ test_construct;
-      (*= test_construct_no_total_order; *)
-      test_construct_no_total_order_actual;
-      test_find ~input:0 ~expected:(Some "1");
-      test_find ~input:1 ~expected:(Some "2");
-      test_find ~input:2 ~expected:(Some "0");
-      test_find ~input:3 ~expected:(Some "4");
-      test_find ~input:4 ~expected:(Some "5");
-      test_find ~input:5 ~expected:(Some "7");
-      test_find ~input:6 ~expected:(Some "7");
-      test_find ~input:7 ~expected:(Some "6");
-      test_find ~input:8 ~expected:(Some "8");
-      test_find ~input:9 ~expected:(Some "9");
+    [ test_of_alist_exn;
+      test_empty_list;
+      test_invalid_interval;
+      test_find ~input:0 ~expected:(Some "a");
+      test_find ~input:1 ~expected:(Some "b");
+      test_find ~input:2 ~expected:(Some "j");
+      test_find ~input:3 ~expected:(Some "d");
+      test_find ~input:4 ~expected:(Some "e");
+      test_find ~input:5 ~expected:(Some "g");
+      test_find ~input:6 ~expected:(Some "g");
+      test_find ~input:7 ~expected:(Some "f");
+      test_find ~input:8 ~expected:(Some "h");
+      test_find ~input:9 ~expected:(Some "i");
       test_find ~input:10 ~expected:None;
       test_find_first
     ] )

--- a/tests/test-units/analysis/overrides_interval_tree_test.ml
+++ b/tests/test-units/analysis/overrides_interval_tree_test.ml
@@ -1,10 +1,18 @@
 open Merlin_analysis
 
+let create_position pos_cnum =
+  { Lexing.pos_fname = "test.ml"; pos_lnum = 1; pos_bol = 0; pos_cnum }
+
 let create_tree intervals =
   intervals
   |> List.map (fun ((low, high), payload) ->
-         Result.get_ok
-           (Overrides_interval_tree.Interval.create ~low ~high ~payload))
+         let loc =
+           { Location.loc_start = create_position low;
+             loc_end = create_position high;
+             loc_ghost = false
+           }
+         in
+         Result.get_ok (Overrides_interval_tree.Interval.create ~loc ~payload))
   |> Overrides_interval_tree.of_alist
 
 let test_of_alist_exn =
@@ -20,8 +28,7 @@ let test_of_alist_exn =
             ((5, 10), "6");
             ((5, 7), "7");
             ((8, 10), "8");
-            ((0, 2), "9");
-            ((2, 2), "10")
+            ((0, 2), "9")
           ]
       in
       ())
@@ -29,9 +36,14 @@ let test_of_alist_exn =
 let test_invalid_interval =
   let open Alcotest in
   test_case "test creating invalid interval" `Quick (fun () ->
+      let loc =
+        { Location.loc_start = create_position 5;
+          loc_end = create_position 0;
+          loc_ghost = false
+        }
+      in
       let interval =
-        Overrides_interval_tree.Interval.create ~low:5 ~high:0
-          ~payload:"invalid"
+        Overrides_interval_tree.Interval.create ~loc ~payload:"invalid"
       in
       let is_ok = Result.is_ok interval in
       check bool "should be equal" is_ok false)
@@ -39,11 +51,10 @@ let test_invalid_interval =
 let test_find ~input ~expected =
   (*
     0 1 2 3 4 5 6 7 8 9 10
-    ----------e---------
-    ----d---  -----f----
-    ---b--    --g-  --h-
-    -a  -c            -i
-        j
+    ----------e----------
+    ----d---- -----f-----
+    ---b---   --g-- --h--
+    -a- -c-           -i-
    *)
   let tree =
     create_tree
@@ -53,10 +64,9 @@ let test_find ~input ~expected =
         ((0, 4), "d");
         ((0, 10), "e");
         ((5, 10), "f");
-        ((5, 7), "g");
+        ((5, 6), "g");
         ((8, 10), "h");
-        ((9, 10), "i");
-        ((2, 2), "j")
+        ((9, 10), "i")
       ]
   in
   let open Alcotest in
@@ -64,15 +74,17 @@ let test_find ~input ~expected =
     ("test find on input " ^ Int.to_string input)
     `Quick
     (fun () ->
-      let payload = Overrides_interval_tree.find tree input in
+      let pos = create_position input in
+      let payload = Overrides_interval_tree.find tree pos in
       check (option string) "should be equal" expected payload)
 
-let test_find_first =
-  let tree = create_tree [ ((0, 4), "0"); ((2, 2), "1"); ((2, 2), "2") ] in
+let _test_find_first =
+  let tree = create_tree [ ((0, 4), "0"); ((2, 3), "1"); ((2, 3), "2") ] in
   let open Alcotest in
   test_case "test find on input with duplicate intervals" `Quick (fun () ->
       let expected = Some "1" in
-      let payload = Overrides_interval_tree.find tree 2 in
+      let pos = create_position 2 in
+      let payload = Overrides_interval_tree.find tree pos in
       check (option string) "should be equal" expected payload)
 
 let test_find_empty =
@@ -80,7 +92,8 @@ let test_find_empty =
   let open Alcotest in
   test_case "test find on empty tree" `Quick (fun () ->
       let expected = None in
-      let payload = Overrides_interval_tree.find tree 0 in
+      let pos = create_position 0 in
+      let payload = Overrides_interval_tree.find tree pos in
       check (option string) "should be equal" expected payload)
 
 let cases =
@@ -88,16 +101,16 @@ let cases =
     [ test_of_alist_exn;
       test_invalid_interval;
       test_find ~input:0 ~expected:(Some "a");
-      test_find ~input:1 ~expected:(Some "b");
-      test_find ~input:2 ~expected:(Some "j");
-      test_find ~input:3 ~expected:(Some "d");
-      test_find ~input:4 ~expected:(Some "e");
+      test_find ~input:1 ~expected:(Some "a");
+      test_find ~input:2 ~expected:(Some "c");
+      test_find ~input:3 ~expected:(Some "c");
+      test_find ~input:4 ~expected:(Some "d");
       test_find ~input:5 ~expected:(Some "g");
       test_find ~input:6 ~expected:(Some "g");
       test_find ~input:7 ~expected:(Some "f");
       test_find ~input:8 ~expected:(Some "h");
       test_find ~input:9 ~expected:(Some "i");
-      test_find ~input:10 ~expected:None;
-      test_find_first;
+      test_find ~input:10 ~expected:(Some "i");
+      test_find ~input:11 ~expected:None;
       test_find_empty
     ] )

--- a/tests/test-units/analysis/overrides_interval_tree_test.ml
+++ b/tests/test-units/analysis/overrides_interval_tree_test.ml
@@ -25,6 +25,16 @@ let test_construct =
       in
       ())
 
+let test_construct_no_total_order =
+  let open Alcotest in
+  test_case "test construction of intervals without total ordering" `Quick
+    (fun () ->
+      check_raises "should raise exn"
+        (Invalid_argument "input interval es do not follow a total ordering")
+        (fun () ->
+          let _ = create_intervals [ ((0, 3), "1"); ((1, 4), "2") ] in
+          ()))
+
 let test_find ~input ~expected =
   (*
     0 1 2 3 4 5 6 7 8 9 10
@@ -56,9 +66,18 @@ let test_find ~input ~expected =
       let payload = Overrides_interval_tree.find tree input in
       check (option string) "should be equal" expected payload)
 
+let test_find_first =
+  let tree = create_intervals [ ((0, 4), "0"); ((2, 2), "1"); ((2, 2), "2") ] in
+  let open Alcotest in
+  test_case "test find on input with duplicate intervals" `Quick (fun () ->
+      let expected = Some "1" in
+      let payload = Overrides_interval_tree.find tree 2 in
+      check (option string) "should be equal" expected payload)
+
 let cases =
   ( "overrides-interval-tree",
     [ test_construct;
+      test_construct_no_total_order;
       test_find ~input:0 ~expected:(Some "1");
       test_find ~input:1 ~expected:(Some "2");
       test_find ~input:2 ~expected:(Some "0");
@@ -69,5 +88,6 @@ let cases =
       test_find ~input:7 ~expected:(Some "6");
       test_find ~input:8 ~expected:(Some "8");
       test_find ~input:9 ~expected:(Some "9");
-      test_find ~input:10 ~expected:None
+      test_find ~input:10 ~expected:None;
+      test_find_first
     ] )

--- a/tests/test-units/analysis/overrides_interval_tree_test.ml
+++ b/tests/test-units/analysis/overrides_interval_tree_test.ml
@@ -1,0 +1,22 @@
+open Merlin_analysis.Overrides_interval_tree
+
+let test_construct_1 =
+  let open Alcotest in
+  test_case "test basic list construction" `Quick (fun () ->
+      let lst =
+        [ ((0, 1), "1");
+          ((0, 3), "2");
+          ((2, 3), "3");
+          ((0, 4), "4");
+          ((0, 10), "5");
+          ((5, 10), "6");
+          ((5, 7), "7");
+          ((8, 10), "8")
+        ]
+      in
+      let tree = Result.get_ok (Interval_tree.of_alist lst) in
+      let expected = [ "3"; "2"; "4"; "5" ] in
+      let payloads = Interval_tree.find tree 2 in
+      check (list string) "should be equal" expected payloads)
+
+let cases = ("overrides-interval-tree", [ test_construct_1 ])

--- a/tests/test-units/analysis/overrides_interval_tree_test.ml
+++ b/tests/test-units/analysis/overrides_interval_tree_test.ml
@@ -75,6 +75,14 @@ let test_find_first =
       let payload = Overrides_interval_tree.find tree 2 in
       check (option string) "should be equal" expected payload)
 
+let test_find_empty =
+  let tree = create_tree [] in
+  let open Alcotest in
+  test_case "test find on empty tree" `Quick (fun () ->
+      let expected = None in
+      let payload = Overrides_interval_tree.find tree 0 in
+      check (option string) "should be equal" expected payload)
+
 let cases =
   ( "overrides-interval-tree",
     [ test_of_alist_exn;
@@ -90,5 +98,6 @@ let cases =
       test_find ~input:8 ~expected:(Some "h");
       test_find ~input:9 ~expected:(Some "i");
       test_find ~input:10 ~expected:None;
-      test_find_first
+      test_find_first;
+      test_find_empty
     ] )

--- a/tests/test-units/analysis/overrides_interval_tree_test.ml
+++ b/tests/test-units/analysis/overrides_interval_tree_test.ml
@@ -54,13 +54,13 @@ let test_find ~input ~expected =
     ----------e----------
     ----d---- -----f-----
     ---b---   --g-- --h--
-    -a- -c-           -i-
+    -a- c             -i-
    *)
   let tree =
     create_tree
       [ ((0, 1), "a");
         ((0, 3), "b");
-        ((2, 3), "c");
+        ((2, 2), "c");
         ((0, 4), "d");
         ((0, 10), "e");
         ((5, 10), "f");
@@ -103,7 +103,7 @@ let cases =
       test_find ~input:0 ~expected:(Some "a");
       test_find ~input:1 ~expected:(Some "a");
       test_find ~input:2 ~expected:(Some "c");
-      test_find ~input:3 ~expected:(Some "c");
+      test_find ~input:3 ~expected:(Some "b");
       test_find ~input:4 ~expected:(Some "d");
       test_find ~input:5 ~expected:(Some "g");
       test_find ~input:6 ~expected:(Some "g");

--- a/tests/test-units/analysis/overrides_interval_tree_test.mli
+++ b/tests/test-units/analysis/overrides_interval_tree_test.mli
@@ -1,0 +1,1 @@
+val cases : string * unit Alcotest.test_case list


### PR DESCRIPTION
Implements interval tree and refactors overrides to use this new data structure. The chosen interval tree design is based off of [this description](https://en.wikipedia.org/wiki/Interval_tree#Centered_interval_tree). 

## Testing 

Added unit tests for invalid inputs and common happy path cases. 

Testing story can possibly be improved with more edge case testing. 