### PR TITLE
Add update-flake-lock workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,22 @@
+name: "Flake.lock: update Nix dependencies"
+
+# This workflow will open a PR to update the flake.lock file if it is out of sync with the
+# flake.nix file.
+
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+jobs:
+  nix-flake-update:
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/update-flake-lock@main


### PR DESCRIPTION
This PR adds a new GitHub action that will open a PR if the `flake.lock` file is out of sync with the `flake.nix` file. See https://github.com/marketplace/actions/update-nix-flake-lock.